### PR TITLE
refactor: add useLoginMutation abstraction

### DIFF
--- a/src/components/app/data/hooks/index.ts
+++ b/src/components/app/data/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useNProgressLoader, type UseNProgressLoaderOptions } from './useNProgressLoader';
 export { default as useBFFContext } from './useBFFContext';
 export { default as useBFFValidation } from './useBFFValidation';
+export { default as useLoginMutation } from './useLoginMutation';

--- a/src/components/app/data/hooks/tests/useLoginMutation.test.tsx
+++ b/src/components/app/data/hooks/tests/useLoginMutation.test.tsx
@@ -1,0 +1,294 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { AxiosError, AxiosResponse } from 'axios';
+import React from 'react';
+
+import loginRequest from '@/components/app/data/services/login';
+
+import useLoginMutation from '../useLoginMutation';
+
+// Mock the login service
+jest.mock('@/components/app/data/services/login');
+
+/**
+ * Helper function to create a test wrapper with QueryClient
+ */
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  return wrapper;
+};
+
+/**
+ * Helper function to create a mock login request
+ */
+const createMockLoginRequest = (overrides = {}): LoginRequestSchema => ({
+  emailOrUsername: 'test@example.com',
+  password: 'password123',
+  ...overrides,
+});
+
+/**
+ * Helper function to create a mock successful response
+ */
+const createMockSuccessResponse = (overrides = {}): AxiosResponse<LoginSuccessResponseSchema> => ({
+  data: {
+    redirectUrl: '/dashboard',
+    success: true,
+    ...overrides,
+  },
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as any,
+});
+
+/**
+ * Helper function to create a mock error response
+ */
+const createMockErrorResponse = (overrides = {}): AxiosError<LoginErrorResponseSchema> => {
+  const errorData: LoginErrorResponseSchema = {
+    nonFieldErrors: ['Invalid email or password'],
+    ...overrides,
+  };
+
+  return new AxiosError(
+    'Request failed with status code 400',
+    '400',
+    undefined,
+    undefined,
+    {
+      status: 400,
+      statusText: 'Bad Request',
+      data: errorData,
+      headers: {},
+      config: {} as any,
+    },
+  );
+};
+
+describe('useLoginMutation', () => {
+  const mockLoginRequest = loginRequest as jest.MockedFunction<typeof loginRequest>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully call loginRequest and trigger onSuccess callback', async () => {
+    // Setup
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+    const mockRequestData = createMockLoginRequest();
+    const mockResponse = createMockSuccessResponse();
+
+    mockLoginRequest.mockResolvedValue(mockResponse);
+
+    // Execute
+    const { result } = renderHook(
+      () => useLoginMutation({
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    result.current.mutate(mockRequestData);
+
+    // Verify
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockLoginRequest).toHaveBeenCalledWith(mockRequestData);
+    expect(mockOnSuccess).toHaveBeenCalledWith(mockResponse.data);
+    expect(mockOnError).not.toHaveBeenCalled();
+  });
+
+  it('should handle error with non-field errors and trigger onError callback with default message', async () => {
+    // Setup
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+    const mockRequestData = createMockLoginRequest();
+    const mockError = createMockErrorResponse({
+      nonFieldErrors: ['Invalid credentials provided'],
+    });
+
+    mockLoginRequest.mockRejectedValue(mockError);
+
+    // Execute
+    const { result } = renderHook(
+      () => useLoginMutation({
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    result.current.mutate(mockRequestData);
+
+    // Verify
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockLoginRequest).toHaveBeenCalledWith(mockRequestData);
+    expect(mockOnError).toHaveBeenCalledWith('Invalid credentials provided');
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should handle error without response and use default error message', async () => {
+    // Setup
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+    const mockRequestData = createMockLoginRequest();
+    const mockError = new AxiosError('Network Error');
+
+    mockLoginRequest.mockRejectedValue(mockError);
+
+    // Execute
+    const { result } = renderHook(
+      () => useLoginMutation({
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    result.current.mutate(mockRequestData);
+
+    // Verify
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockLoginRequest).toHaveBeenCalledWith(mockRequestData);
+    expect(mockOnError).toHaveBeenCalledWith('Invalid email or password');
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should handle error without nonFieldErrors and use default message', async () => {
+    // Setup
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+    const mockRequestData = createMockLoginRequest();
+    const mockError = createMockErrorResponse({
+      email: ['This field is required.'],
+      password: ['This field is required.'],
+    });
+
+    // Remove nonFieldErrors from the error
+    delete mockError.response?.data.nonFieldErrors;
+
+    mockLoginRequest.mockRejectedValue(mockError);
+
+    // Execute
+    const { result } = renderHook(
+      () => useLoginMutation({
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    result.current.mutate(mockRequestData);
+
+    // Verify
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockLoginRequest).toHaveBeenCalledWith(mockRequestData);
+    expect(mockOnError).toHaveBeenCalledWith('Invalid email or password');
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should forward additional mutation config options', async () => {
+    // Setup
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+    const mockOnMutate = jest.fn();
+    const mockRequestData = createMockLoginRequest();
+    const mockResponse = createMockSuccessResponse();
+
+    mockLoginRequest.mockResolvedValue(mockResponse);
+
+    // Execute
+    const { result } = renderHook(
+      () => useLoginMutation({
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+        onMutate: mockOnMutate,
+        retry: 3,
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    result.current.mutate(mockRequestData);
+
+    // Verify
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockOnMutate).toHaveBeenCalledWith(mockRequestData);
+    expect(mockOnSuccess).toHaveBeenCalledWith(mockResponse.data);
+  });
+
+  it('should provide loading state during mutation', async () => {
+    // Setup
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+    const mockRequestData = createMockLoginRequest();
+    const mockResponse = createMockSuccessResponse();
+
+    // Create a promise that we can control
+    let resolveLogin: (value: any) => void;
+    const loginPromise = new Promise((resolve) => {
+      resolveLogin = resolve;
+    });
+
+    mockLoginRequest.mockReturnValue(loginPromise as any);
+
+    // Execute
+    const { result } = renderHook(
+      () => useLoginMutation({
+        onSuccess: mockOnSuccess,
+        onError: mockOnError,
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    // Start mutation
+    result.current.mutate(mockRequestData);
+
+    // Verify loading state
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.isError).toBe(false);
+
+    // Resolve the promise
+    resolveLogin!(mockResponse);
+
+    // Verify final state
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(mockOnSuccess).toHaveBeenCalledWith(mockResponse.data);
+  });
+});

--- a/src/components/app/data/hooks/useLoginMutation.ts
+++ b/src/components/app/data/hooks/useLoginMutation.ts
@@ -1,0 +1,35 @@
+import { useMutation } from '@tanstack/react-query';
+
+import loginRequest from '@/components/app/data/services/login';
+
+import type { AxiosError, AxiosResponse } from 'axios';
+
+interface UseLoginMutationProps {
+  onSuccess: (data: LoginSuccessResponseSchema) => void;
+  onError: (errorMessage: string) => void;
+  [key: string]: any;
+}
+
+/*
+ * Provide a thin useMutation abstraction around loginRequest to protect the
+ * caller from being aware of Axios.
+ */
+export default function useLoginMutation({
+  onSuccess,
+  onError,
+  ...mutationConfig
+}: UseLoginMutationProps) {
+  return useMutation<
+  AxiosResponse<LoginSuccessResponseSchema>,
+  AxiosError<LoginErrorResponseSchema>,
+  LoginRequestSchema
+  >({
+    mutationFn: (requestData) => loginRequest(requestData),
+    onSuccess: (axiosResponse) => onSuccess(axiosResponse.data),
+    onError: (axiosError) => {
+      const errorMessage: string = axiosError?.response?.data?.nonFieldErrors?.[0] || 'Invalid email or password';
+      onError(errorMessage);
+    },
+    ...mutationConfig,
+  });
+}

--- a/src/components/app/data/services/login.ts
+++ b/src/components/app/data/services/login.ts
@@ -1,25 +1,78 @@
-import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform/config';
 import { camelCaseObject, snakeCaseObject } from '@edx/frontend-platform/utils';
 
 import type { AxiosResponse } from 'axios';
 
 /**
+ * ==============================
+ * Login Request/Response Types
+ * ==============================
+ */
+
+declare global {
+  /**
+   * Data structure for a login request payload.
+   */
+  interface LoginRequestSchema {
+    emailOrUsername: string;
+    password: string;
+  }
+
+  /**
+   * Data structure for a login response payload.
+   */
+  interface LoginSuccessResponseSchema {
+    redirectUrl: string;
+    success: boolean;
+  }
+
+  /**
+   * Data structure for an error response payload.
+   */
+  interface LoginErrorResponseSchema {
+    nonFieldErrors?: string[];
+    email?: string[];
+    password?: string[];
+    detail?: string;
+  }
+
+  type LoginResponseSchema = LoginSuccessResponseSchema | LoginErrorResponseSchema;
+
+  /**
+   * Snake_cased versions of above schemas for API communication
+   */
+  type LoginRequestPayload = Payload<LoginRequestSchema>;
+  type LoginResponsePayload = Payload<LoginResponseSchema>;
+  type LoginSuccessResponsePayload = Payload<LoginSuccessResponseSchema>;
+  type LoginErrorResponsePayload = Payload<LoginErrorResponseSchema>;
+}
+
+/**
  * Login service that calls the edx-platform login endpoint.
  * Based on loginRequest from frontend-app-authn.
+ *
+ * @throws {AxiosError<LoginErrorResponseSchema>}
  */
-export default async function loginRequest(requestData: LoginRequestSchema): Promise<LoginResponseSchema> {
+export default async function loginRequest(
+  requestData: LoginRequestSchema,
+): Promise<AxiosResponse<LoginSuccessResponseSchema>> {
   const requestPayload: LoginRequestPayload = snakeCaseObject(requestData);
   const requestConfig = {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     // Avoid eagerly intercepting the call to refresh the JWT token---it won't work so don't even try.
     isPublic: true,
+    // Convert response payload (success or error) to a response schema for use by callers.
+    transformResponse: [
+      (data: LoginResponsePayload): LoginResponseSchema => camelCaseObject(data),
+    ],
   };
-  const response: AxiosResponse<LoginResponsePayload> = await getAuthenticatedHttpClient().post<LoginResponsePayload>(
-    `${getConfig().LMS_BASE_URL}/api/user/v2/account/login_session/`,
-    (new URLSearchParams(requestPayload)).toString(),
-    requestConfig,
+  const response: AxiosResponse<LoginSuccessResponseSchema> = (
+    await getAuthenticatedHttpClient().post<LoginSuccessResponsePayload>(
+      `${getConfig().LMS_BASE_URL}/api/user/v2/account/login_session/`,
+      (new URLSearchParams(requestPayload)).toString(),
+      requestConfig,
+    )
   );
-
-  return camelCaseObject(response.data);
+  return response;
 }

--- a/src/components/app/data/services/tests/login.test.ts
+++ b/src/components/app/data/services/tests/login.test.ts
@@ -1,0 +1,217 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform/config';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import loginRequest from '../login';
+
+// Mock setup
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/config', () => ({
+  getConfig: jest.fn(),
+}));
+
+/**
+ * Helper function to create a mock login request payload
+ */
+const createMockLoginRequest = (overrides = {}): LoginRequestSchema => ({
+  emailOrUsername: 'test@example.com',
+  password: 'password123',
+  ...overrides,
+});
+
+/**
+ * Helper function to create a mock successful login response
+ */
+const createMockSuccessResponse = (overrides = {}): LoginSuccessResponseSchema => ({
+  redirectUrl: '/dashboard',
+  success: true,
+  ...overrides,
+});
+
+/**
+ * Helper function to create a mock error response
+ */
+const createMockErrorResponse = (overrides = {}): LoginErrorResponseSchema => ({
+  nonFieldErrors: ['Invalid email or password'],
+  ...overrides,
+});
+
+/**
+ * Helper function to verify the structure of a successful login response
+ */
+const verifySuccessfulLoginResponse = (response: AxiosResponse<LoginSuccessResponseSchema>): void => {
+  expect(response.data).toHaveProperty('redirectUrl');
+  expect(response.data).toHaveProperty('success');
+  expect(typeof response.data.redirectUrl).toBe('string');
+  expect(typeof response.data.success).toBe('boolean');
+  expect(response.data.success).toBe(true);
+};
+
+describe('loginRequest', () => {
+  const mockPost = jest.fn();
+  const mockConfig = {
+    LMS_BASE_URL: 'https://example.com',
+  };
+  const baseUrl = 'https://example.com/api/user/v2/account/login_session/';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getAuthenticatedHttpClient as jest.Mock).mockReturnValue({
+      post: mockPost,
+    });
+    (getConfig as jest.Mock).mockReturnValue(mockConfig);
+  });
+
+  it('should call the correct URL with the correct payload and headers', async () => {
+    // Setup
+    const mockRequestData = createMockLoginRequest();
+    const mockSuccessResponse = {
+      data: createMockSuccessResponse(),
+    };
+    mockPost.mockResolvedValue(mockSuccessResponse);
+
+    // Execute
+    await loginRequest(mockRequestData);
+
+    // Verify
+    expect(getConfig).toHaveBeenCalled();
+    expect(getAuthenticatedHttpClient).toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalledWith(
+      baseUrl,
+      'email_or_username=test%40example.com&password=password123',
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        isPublic: true,
+        transformResponse: expect.any(Array),
+      }),
+    );
+  });
+
+  it('should return a successful response from the API', async () => {
+    // Setup
+    const mockRequestData = createMockLoginRequest();
+    const mockSuccessResponse = {
+      data: createMockSuccessResponse(),
+    };
+    mockPost.mockResolvedValue(mockSuccessResponse);
+
+    // Execute
+    const result = await loginRequest(mockRequestData);
+
+    // Verify
+    verifySuccessfulLoginResponse(result);
+    expect(result.data.redirectUrl).toBe('/dashboard');
+    expect(result.data.success).toBe(true);
+  });
+
+  it('should handle different successful response data', async () => {
+    // Setup
+    const mockRequestData = createMockLoginRequest({
+      emailOrUsername: 'user@test.com',
+    });
+    const mockSuccessResponse = {
+      data: createMockSuccessResponse({
+        redirectUrl: '/custom-redirect',
+        success: true,
+      }),
+    };
+    mockPost.mockResolvedValue(mockSuccessResponse);
+
+    // Execute
+    const result = await loginRequest(mockRequestData);
+
+    // Verify
+    verifySuccessfulLoginResponse(result);
+    expect(result.data.redirectUrl).toBe('/custom-redirect');
+  });
+
+  it('should throw AxiosError with non-field errors when login fails', async () => {
+    // Setup
+    const mockRequestData = createMockLoginRequest({
+      emailOrUsername: 'invalid@example.com',
+      password: 'wrongpassword',
+    });
+    const mockErrorResponse = createMockErrorResponse({
+      nonFieldErrors: ['Invalid email or password'],
+    });
+
+    const axiosError = new AxiosError(
+      'Request failed with status code 400',
+      '400',
+      undefined,
+      undefined,
+      {
+        status: 400,
+        statusText: 'Bad Request',
+        data: mockErrorResponse,
+        headers: {},
+        config: {},
+      } as AxiosResponse<LoginErrorResponseSchema>,
+    );
+
+    mockPost.mockRejectedValue(axiosError);
+
+    // Execute & Verify
+    await expect(loginRequest(mockRequestData)).rejects.toThrow(AxiosError);
+    await expect(loginRequest(mockRequestData)).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: {
+          nonFieldErrors: ['Invalid email or password'],
+        },
+      },
+    });
+  });
+
+  it('should throw AxiosError with field-specific errors', async () => {
+    // Setup
+    const mockRequestData = createMockLoginRequest({
+      emailOrUsername: '',
+      password: '',
+    });
+    const mockErrorResponse = createMockErrorResponse({
+      email: ['This field is required.'],
+      password: ['This field is required.'],
+    });
+
+    const axiosError = new AxiosError(
+      'Request failed with status code 400',
+      '400',
+      undefined,
+      undefined,
+      {
+        status: 400,
+        statusText: 'Bad Request',
+        data: mockErrorResponse,
+        headers: {},
+        config: {},
+      } as AxiosResponse<LoginErrorResponseSchema>,
+    );
+
+    mockPost.mockRejectedValue(axiosError);
+
+    // Execute & Verify
+    await expect(loginRequest(mockRequestData)).rejects.toThrow(AxiosError);
+    await expect(loginRequest(mockRequestData)).rejects.toMatchObject({
+      response: {
+        data: {
+          email: ['This field is required.'],
+          password: ['This field is required.'],
+        },
+      },
+    });
+  });
+
+  it('should throw an error if the API call fails with network error', async () => {
+    // Setup
+    const mockRequestData = createMockLoginRequest();
+    const mockError = new Error('Network error');
+    mockPost.mockRejectedValue(mockError);
+
+    // Execute & Verify
+    await expect(loginRequest(mockRequestData)).rejects.toThrow('Network error');
+  });
+});

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -7,14 +7,13 @@ import {
   Stack,
   Stepper,
 } from '@openedx/paragon';
-import { useMutation } from '@tanstack/react-query';
 import { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 
-import loginRequest from '@/components/app/data/services/login';
+import { useLoginMutation } from '@/components/app/data/hooks';
 import { useStepperContent } from '@/components/Stepper/Steps/hooks';
 import {
   CheckoutPageDetails,
@@ -56,14 +55,11 @@ const PlanDetailsPage = () => {
     setError,
   } = form;
 
-  const loginMutation = useMutation({
-    mutationFn: (requestData: LoginRequestSchema) => loginRequest(requestData),
+  const loginMutation = useLoginMutation({
     onSuccess: () => {
       navigate(CheckoutPageDetails.PlanDetails.route);
     },
-    onError: (error: any) => {
-      // Handle login errors
-      const errorMessage = error?.response?.data?.non_field_errors?.[0] || 'Invalid email or password';
+    onError: (errorMessage) => {
       setError('password', {
         type: 'manual',
         message: errorMessage,

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -329,36 +329,4 @@ declare global {
     upperMarginMs?: number;
   }
   function assertDebounce(options: DebounceTestOptions): Promise<{ elapsedMs: number }>;
-
-  /**
-   * ==============================
-   * Login Request/Response Types
-   * ==============================
-   */
-
-  /**
-   * Data structure for a login request payload.
-   */
-  interface LoginRequestSchema {
-    emailOrUsername: string;
-    password: string;
-  }
-
-  /**
-   * Snake-cased version of LoginRequestSchema for API communication
-   */
-  type LoginRequestPayload = Payload<LoginRequestSchema>;
-
-  /**
-   * Data structure for a login response payload.
-   */
-  interface LoginResponseSchema {
-    redirectUrl: string;
-    success: boolean;
-  }
-
-  /**
-   * Snake-cased version of LoginResponseSchema for API communication
-   */
-  type LoginResponsePayload = Payload<LoginResponseSchema>;
 }


### PR DESCRIPTION
Introduce a new abstraction layer (useLoginMutation) for better separation of concerns:

1. The service function `loginRequest` is ONLY concerned with transforming between camelCase<->snake_case,
2. the useLoginMutation hook is ONLY concerned about navigating Axios internal structures, and
3. the consuming component is ONLY concerned with defining what exactly to do with the resulting data.

This pattern can be re-used for registration.