### PR TITLE
feat: [AccountDetails] Implement StatefulButton

### DIFF
--- a/src/components/account-details-page/AccountDetailsPage.tsx
+++ b/src/components/account-details-page/AccountDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -27,8 +27,9 @@ import {
   useCurrentPageDetails,
 } from '@/hooks/index';
 
+import AccountDetailsSubmitButton from './AccountDetailsSubmitButton';
+
 const AccountDetailsPage: React.FC = () => {
-  const intl = useIntl();
   const { data: formValidationConstraints } = useFormValidationConstraints();
   const navigate = useNavigate();
   const accountDetailsFormData = useCheckoutFormStore((state) => state.formData[DataStoreKey.AccountDetails]);
@@ -106,7 +107,10 @@ const AccountDetailsPage: React.FC = () => {
   });
 
   const onSubmit = (data: AccountDetailsData) => {
+    // Update form state with new field values.
     setFormData(DataStoreKey.AccountDetails, data);
+
+    // TODO: Emit Segment event representing the account details page continue button was clicked.
 
     // Create a new checkout session needed for the billing details page (next).
     const { companyName, enterpriseSlug } = data;
@@ -145,14 +149,11 @@ const AccountDetailsPage: React.FC = () => {
             />
           </Button>
           <Stepper.ActionRow.Spacer />
-          <Button
-            variant="secondary"
-            type="submit"
-            disabled={!isValid}
-            data-testid="stepper-submit-button"
-          >
-            {intl.formatMessage(stepperActionButtonMessage)}
-          </Button>
+          <AccountDetailsSubmitButton
+            formIsValid={isValid}
+            submissionIsPending={createCheckoutSessionMutation.isPending}
+            submissionIsSuccess={createCheckoutSessionMutation.isSuccess}
+          />
         </Stepper.ActionRow>
         )}
       </Stack>

--- a/src/components/account-details-page/AccountDetailsSubmitButton.tsx
+++ b/src/components/account-details-page/AccountDetailsSubmitButton.tsx
@@ -1,0 +1,61 @@
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Icon, StatefulButton } from '@openedx/paragon';
+import { CheckCircleOutline, SpinnerSimple } from '@openedx/paragon/icons';
+
+import { useCurrentPageDetails } from '@/hooks/index';
+
+interface AccountDetailsSubmitButtonProps {
+  formIsValid: boolean;
+  submissionIsPending: boolean;
+  submissionIsSuccess: boolean;
+}
+
+const AccountDetailsSubmitButton = ({
+  formIsValid,
+  submissionIsPending,
+  submissionIsSuccess,
+}: AccountDetailsSubmitButtonProps) => {
+  const intl = useIntl();
+  const { buttonMessage } = useCurrentPageDetails();
+
+  let buttonState: 'inactive' | 'default' | 'pending' | 'complete' = 'default';
+  if (submissionIsPending) {
+    buttonState = 'pending';
+  } else if (submissionIsSuccess) {
+    buttonState = 'complete';
+  } else if (!formIsValid) {
+    buttonState = 'inactive';
+  }
+
+  return (
+    <StatefulButton
+      type="submit"
+      state={buttonState}
+      labels={{
+        inactive: intl.formatMessage(buttonMessage),
+        default: intl.formatMessage(buttonMessage),
+        pending: intl.formatMessage({
+          id: 'checkout.submitting',
+          defaultMessage: 'Submitting...',
+          description: 'Button label when the form is being submitted',
+        }),
+        complete: intl.formatMessage({
+          id: 'checkout.submitted',
+          defaultMessage: 'Submitted',
+          description: 'Button label when the form has been submitted successfully',
+        }),
+      }}
+      icons={{
+        inactive: undefined,
+        default: undefined,
+        pending: <Icon src={SpinnerSimple} className="icon-spin" />,
+        complete: <Icon src={CheckCircleOutline} />,
+      }}
+      disabledStates={['inactive', 'pending', 'complete']}
+      variant="secondary"
+      data-testid="stepper-submit-button"
+    />
+  );
+};
+
+export default AccountDetailsSubmitButton;

--- a/src/components/account-details-page/tests/AccountDetailsSubmitButton.test.tsx
+++ b/src/components/account-details-page/tests/AccountDetailsSubmitButton.test.tsx
@@ -1,0 +1,112 @@
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { useCurrentPageDetails } from '@/hooks/index';
+
+import AccountDetailsSubmitButton from '../AccountDetailsSubmitButton';
+
+// Mock useIntl and useCurrentPageDetails
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  useIntl: jest.fn(),
+}));
+
+// Mock useCurrentPageDetails().buttonMessage
+jest.mock('@/hooks/index', () => ({
+  useCurrentPageDetails: jest.fn(),
+}));
+(useCurrentPageDetails as jest.Mock).mockReturnValue({
+  buttonMessage: {
+    id: 'checkout.continue',
+    defaultMessage: 'Continue',
+    description: 'Continue to next step',
+  },
+});
+
+function setup(props = {
+  formIsValid: false,
+  submissionIsPending: false,
+  submissionIsSuccess: false,
+}) {
+  // Mock the formatMessage implementation to return the message descriptor's defaultMessage or id
+  const formatMessage = jest.fn(
+    (descriptor) => descriptor.defaultMessage || descriptor.id || String(descriptor),
+  );
+  (useIntl as jest.Mock).mockReturnValue({ formatMessage });
+
+  return render(<AccountDetailsSubmitButton {...props} />);
+}
+
+describe('AccountDetailsSubmitButton', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default state and enabled', () => {
+    setup({
+      formIsValid: true,
+      submissionIsPending: false,
+      submissionIsSuccess: false,
+    });
+    const button = screen.getByTestId('stepper-submit-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Continue');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('renders as disabled when form is not valid', () => {
+    setup({
+      formIsValid: false,
+      submissionIsPending: false,
+      submissionIsSuccess: false,
+    });
+    const button = screen.getByTestId('stepper-submit-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Continue');
+    // The button should be disabled (aria-disabled or disabled attribute)
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows pending state when submission is pending', () => {
+    setup({
+      formIsValid: true,
+      submissionIsPending: true,
+      submissionIsSuccess: false,
+    });
+    const button = screen.getByTestId('stepper-submit-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Submitting...');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    // Should show spinner element
+    expect(button.querySelector('.icon-spin')).toBeInTheDocument();
+  });
+
+  it('shows complete state when submission is successful', () => {
+    setup({
+      formIsValid: true,
+      submissionIsPending: false,
+      submissionIsSuccess: true,
+    });
+    const button = screen.getByTestId('stepper-submit-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Submitted');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    // Should show check icon (CheckCircleOutline)
+    expect(button.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('prioritizes complete state over invalid form', () => {
+    setup({
+      formIsValid: false,
+      submissionIsPending: false,
+      submissionIsSuccess: true,
+    });
+    const button = screen.getByTestId('stepper-submit-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Submitted');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    // Should show check icon (CheckCircleOutline)
+    expect(button.querySelector('svg')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
ENT-10757

Demo recording shows all 4 states in this order:

1. default (valid form)
2. inactive (invalid form)
3. pending (request to create-checkout-session is in flight)
4. complete (split second before redirect)

https://github.com/user-attachments/assets/4a1fee34-9e50-4955-80e6-195ff23957f1


