### PR TITLE
chore: Stop using deprecated prop-types

### DIFF
--- a/src/components/FormFields/AuthenticatedUserField.tsx
+++ b/src/components/FormFields/AuthenticatedUserField.tsx
@@ -1,5 +1,4 @@
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import PropTypes from 'prop-types';
 
 import { FieldContainer } from '@/components/FieldContainer';
 
@@ -8,7 +7,7 @@ interface AuthenticatedUserFieldProps {
   adminEmail: string;
 }
 
-const AuthenticatedUserField: React.FC<AuthenticatedUserFieldProps> = ({ fullName, adminEmail }) => (
+const AuthenticatedUserField = ({ fullName, adminEmail }: AuthenticatedUserFieldProps) => (
   <FieldContainer>
     <div>
       <h3>
@@ -31,10 +30,5 @@ const AuthenticatedUserField: React.FC<AuthenticatedUserFieldProps> = ({ fullNam
     </div>
   </FieldContainer>
 );
-
-AuthenticatedUserField.propTypes = {
-  fullName: PropTypes.string.isRequired,
-  adminEmail: PropTypes.string.isRequired,
-};
 
 export default AuthenticatedUserField;

--- a/src/components/StatefulButton/StatefulPurchaseButton.tsx
+++ b/src/components/StatefulButton/StatefulPurchaseButton.tsx
@@ -1,13 +1,12 @@
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { StatefulButton } from '@openedx/paragon';
 import { Lock } from '@openedx/paragon/icons';
-import PropTypes from 'prop-types';
 
 interface StatefulPurchaseButtonProps {
   isFormValid: boolean;
 }
 
-const StatefulPurchaseButton: React.FC<StatefulPurchaseButtonProps> = ({ isFormValid }) => {
+const StatefulPurchaseButton = ({ isFormValid }: StatefulPurchaseButtonProps) => {
   const intl = useIntl();
   const labels = {
     default: intl.formatMessage({
@@ -47,10 +46,6 @@ const StatefulPurchaseButton: React.FC<StatefulPurchaseButtonProps> = ({ isFormV
       </span>
     </div>
   );
-};
-
-StatefulPurchaseButton.propTypes = {
-  isFormValid: PropTypes.bool.isRequired,
 };
 
 export default StatefulPurchaseButton;


### PR DESCRIPTION
According to the [official react docs](https://react.dev/learn/typescript), it's no longer best practice to use either prop-types or React.FC<> to declare props.  React is now intelligent enough to rely only on Typescript interfaces on the props object. This improves code maintainability by reducing redundant prop listings.

Also, this will silence Copilot AI comments.