### PR TITLE
chore: stop importing deprecated testing-library/jest-dom/extend-expect

### DIFF
--- a/src/components/FormFields/tests/AuthenticatedUserField.test.tsx
+++ b/src/components/FormFields/tests/AuthenticatedUserField.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import AuthenticatedUserField from '../AuthenticatedUserField';
 

--- a/src/components/FormFields/tests/CompanyNameField.test.tsx
+++ b/src/components/FormFields/tests/CompanyNameField.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import CompanyNameField from '../CompanyNameField';
 

--- a/src/components/FormFields/tests/CustomUrlField.test.tsx
+++ b/src/components/FormFields/tests/CustomUrlField.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import CustomUrlField from '../CustomUrlField';
 

--- a/src/components/FormFields/tests/DataPrivacyPolicyField.test.tsx
+++ b/src/components/FormFields/tests/DataPrivacyPolicyField.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import DataPrivacyPolicyField from '../DataPrivacyPolicyField';
 

--- a/src/components/FormFields/tests/Field.test.tsx
+++ b/src/components/FormFields/tests/Field.test.tsx
@@ -1,7 +1,7 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Form } from '@openedx/paragon';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import Field, { getTrailingElement } from '../Field';
 

--- a/src/components/FormFields/tests/LicensesField.test.tsx
+++ b/src/components/FormFields/tests/LicensesField.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import LicensesField from '../LicensesField';
 

--- a/src/components/OrderDetails/tests/OrderDetails.test.tsx
+++ b/src/components/OrderDetails/tests/OrderDetails.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import OrderDetails from '../OrderDetails';
 

--- a/src/components/PurchaseSummary/tests/AutoRenewNotice.test.tsx
+++ b/src/components/PurchaseSummary/tests/AutoRenewNotice.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import AutoRenewNotice from '../AutoRenewNotice';

--- a/src/components/PurchaseSummary/tests/DueTodayRow.test.tsx
+++ b/src/components/PurchaseSummary/tests/DueTodayRow.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import DueTodayRow from '../DueTodayRow';

--- a/src/components/PurchaseSummary/tests/LicensesRow.test.tsx
+++ b/src/components/PurchaseSummary/tests/LicensesRow.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import LicensesRow from '../LicensesRow';

--- a/src/components/PurchaseSummary/tests/PricePerUserRow.test.tsx
+++ b/src/components/PurchaseSummary/tests/PricePerUserRow.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import PricePerUserRow from '../PricePerUserRow';

--- a/src/components/PurchaseSummary/tests/PurchaseSummary.test.tsx
+++ b/src/components/PurchaseSummary/tests/PurchaseSummary.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import { usePurchaseSummaryPricing } from '@/components/app/data';

--- a/src/components/PurchaseSummary/tests/PurchaseSummaryHeader.test.tsx
+++ b/src/components/PurchaseSummary/tests/PurchaseSummaryHeader.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import PurchaseSummaryHeader from '../PurchaseSummaryHeader';

--- a/src/components/PurchaseSummary/tests/SummaryRow.test.tsx
+++ b/src/components/PurchaseSummary/tests/SummaryRow.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import SummaryRow from '../SummaryRow';

--- a/src/components/PurchaseSummary/tests/TotalAfterTrialRow.test.tsx
+++ b/src/components/PurchaseSummary/tests/TotalAfterTrialRow.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import { generateTestPermutations } from '@/utils/tests';

--- a/src/components/SuccessHeading/tests/SuccessHeading.test.tsx
+++ b/src/components/SuccessHeading/tests/SuccessHeading.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import SuccessHeading from '../SuccessHeading';
 

--- a/src/components/SuccessNotification/tests/SuccessNotification.test.tsx
+++ b/src/components/SuccessNotification/tests/SuccessNotification.test.tsx
@@ -1,6 +1,6 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import SuccessNotification from '../SuccessNotification';
 

--- a/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
+++ b/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import { useFormValidationConstraints } from '@/components/app/data';
 import { CheckoutPageRoute } from '@/constants/checkout';

--- a/src/components/app/data/hooks/tests/usePurchaseSummaryPricing.test.tsx
+++ b/src/components/app/data/hooks/tests/usePurchaseSummaryPricing.test.tsx
@@ -1,6 +1,6 @@
 import { AppContext } from '@edx/frontend-platform/react';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import useBFFContext from '@/components/app/data/hooks/useBFFContext';

--- a/src/components/app/tests/Root.test.tsx
+++ b/src/components/app/tests/Root.test.tsx
@@ -2,7 +2,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import Root from '@/components/app/Root';
 import { CheckoutStepKey } from '@/constants/checkout';

--- a/src/components/billing-details-pages/tests/BillingDetailsPage.test.tsx
+++ b/src/components/billing-details-pages/tests/BillingDetailsPage.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import { CheckoutPageRoute, DataStoreKey } from '@/constants/checkout';
 import { checkoutFormStore } from '@/hooks/useCheckoutFormStore';

--- a/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
+++ b/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 import { useFormValidationConstraints } from '@/components/app/data';
 import { CheckoutPageRoute } from '@/constants/checkout';


### PR DESCRIPTION
importing /extend-expect is depcreated in @testing-library/jest-dom 5.x and REMOVED in 6.x. This will make upgrading easier and silence Copilot AI comments.