### PR TITLE
fix: [AccountDetailsPage] support navigating back-and-forth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^18.3.1",
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.54.2",
+        "react-intl": "^6.8.9",
         "react-redux": "^7.2.9",
         "react-router": "^6.29.0",
         "react-router-dom": "^6.29.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.54.2",
+    "react-intl": "^6.8.9",
     "react-redux": "^7.2.9",
     "react-router": "^6.29.0",
     "react-router-dom": "^6.29.0",

--- a/src/components/account-details-page/AccountDetailsSubmitButton.tsx
+++ b/src/components/account-details-page/AccountDetailsSubmitButton.tsx
@@ -1,6 +1,8 @@
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 import { Icon, StatefulButton } from '@openedx/paragon';
-import { CheckCircleOutline, SpinnerSimple } from '@openedx/paragon/icons';
+import { CheckCircleOutline, Refresh, SpinnerSimple } from '@openedx/paragon/icons';
+import { useEffect, useState } from 'react';
+import { MessageDescriptor } from 'react-intl';
 
 import { useCurrentPageDetails } from '@/hooks/index';
 
@@ -8,50 +10,87 @@ interface AccountDetailsSubmitButtonProps {
   formIsValid: boolean;
   submissionIsPending: boolean;
   submissionIsSuccess: boolean;
+  submissionIsError: boolean;
 }
+
+type ButtonState = 'inactive' | 'default' | 'pending' | 'complete' | 'errored';
+
+const overrideButtonMessage: Record<string, MessageDescriptor> = defineMessages({
+  submitting: {
+    id: 'checkout.submitting',
+    defaultMessage: 'Submitting...',
+    description: 'Button label when the form is submitting',
+  },
+  submitted: {
+    id: 'checkout.submitted',
+    defaultMessage: 'Submitted',
+    description: 'Button label when the form has been submitted successfully',
+  },
+  tryAgain: {
+    id: 'checkout.tryAgain',
+    defaultMessage: 'Try Again',
+    description: 'Button label after the form submission errored',
+  },
+});
 
 const AccountDetailsSubmitButton = ({
   formIsValid,
   submissionIsPending,
   submissionIsSuccess,
+  submissionIsError,
 }: AccountDetailsSubmitButtonProps) => {
   const intl = useIntl();
   const { buttonMessage } = useCurrentPageDetails();
 
-  let buttonState: 'inactive' | 'default' | 'pending' | 'complete' = 'default';
-  if (submissionIsPending) {
-    buttonState = 'pending';
-  } else if (submissionIsSuccess) {
-    buttonState = 'complete';
-  } else if (!formIsValid) {
-    buttonState = 'inactive';
-  }
+  // Track the button state with useState for predictable rendering
+  const [buttonState, setButtonState] = useState<ButtonState>('default');
+
+  useEffect(() => {
+    // Determine state order: pending > complete > errored > inactive > default
+    if (submissionIsPending) {
+      setButtonState('pending');
+    } else if (submissionIsSuccess) {
+      setButtonState('complete');
+    } else if (submissionIsError) {
+      setButtonState('errored');
+    } else if (!formIsValid) {
+      setButtonState('inactive');
+    } else {
+      setButtonState('default');
+    }
+  }, [formIsValid, submissionIsPending, submissionIsSuccess, submissionIsError]);
+
+  // Define internationalized button labels
+  const allButtonMessages = {
+    // Inherit the standard button messsage for this checkout step from constants.
+    inactive: buttonMessage,
+    default: buttonMessage,
+
+    // Override the button message in certain scenarios.
+    pending: overrideButtonMessage.submitting,
+    complete: overrideButtonMessage.submitted,
+    errored: overrideButtonMessage.tryAgain,
+  } as Record<ButtonState, MessageDescriptor>;
 
   return (
     <StatefulButton
       type="submit"
       state={buttonState}
       labels={{
-        inactive: intl.formatMessage(buttonMessage),
-        default: intl.formatMessage(buttonMessage),
-        pending: intl.formatMessage({
-          id: 'checkout.submitting',
-          defaultMessage: 'Submitting...',
-          description: 'Button label when the form is being submitted',
-        }),
-        complete: intl.formatMessage({
-          id: 'checkout.submitted',
-          defaultMessage: 'Submitted',
-          description: 'Button label when the form has been submitted successfully',
-        }),
+        inactive: intl.formatMessage(allButtonMessages.inactive),
+        default: intl.formatMessage(allButtonMessages.default),
+        pending: intl.formatMessage(allButtonMessages.pending),
+        complete: intl.formatMessage(allButtonMessages.complete),
+        errored: intl.formatMessage(allButtonMessages.errored),
       }}
       icons={{
         inactive: undefined,
         default: undefined,
         pending: <Icon src={SpinnerSimple} className="icon-spin" />,
         complete: <Icon src={CheckCircleOutline} />,
+        errored: <Icon src={Refresh} />,
       }}
-      disabledStates={['inactive', 'pending', 'complete']}
+      disabledStates={['inactive', 'pending']}
       variant="secondary"
       data-testid="stepper-submit-button"
     />

--- a/src/components/account-details-page/tests/AccountDetailsSubmitButton.test.tsx
+++ b/src/components/account-details-page/tests/AccountDetailsSubmitButton.test.tsx
@@ -9,6 +9,7 @@ import AccountDetailsSubmitButton from '../AccountDetailsSubmitButton';
 
 // Mock useIntl and useCurrentPageDetails
 jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
   useIntl: jest.fn(),
 }));
 
@@ -28,6 +29,7 @@ function setup(props = {
   formIsValid: false,
   submissionIsPending: false,
   submissionIsSuccess: false,
+  submissionIsError: false,
 }) {
   // Mock the formatMessage implementation to return the message descriptor's defaultMessage or id
   const formatMessage = jest.fn(
@@ -48,6 +50,7 @@ describe('AccountDetailsSubmitButton', () => {
       formIsValid: true,
       submissionIsPending: false,
       submissionIsSuccess: false,
+      submissionIsError: false,
     });
     const button = screen.getByTestId('stepper-submit-button');
     expect(button).toBeInTheDocument();
@@ -60,11 +63,14 @@ describe('AccountDetailsSubmitButton', () => {
       formIsValid: false,
       submissionIsPending: false,
       submissionIsSuccess: false,
+      submissionIsError: false,
     });
     const button = screen.getByTestId('stepper-submit-button');
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('Continue');
-    // The button should be disabled (aria-disabled or disabled attribute)
+    // Can't use expect(button).toBeDisabled() because the Paragon StatefulButton doesn't actually
+    // set the `disabled` attribute (no idea why not). Therefore, we need to look at the
+    // aria-disabled attribute instead.
     expect(button).toHaveAttribute('aria-disabled', 'true');
   });
 
@@ -73,12 +79,16 @@ describe('AccountDetailsSubmitButton', () => {
       formIsValid: true,
       submissionIsPending: true,
       submissionIsSuccess: false,
+      submissionIsError: false,
     });
     const button = screen.getByTestId('stepper-submit-button');
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('Submitting...');
+    // Can't use expect(button).toBeDisabled() because the Paragon StatefulButton doesn't actually
+    // set the `disabled` attribute (no idea why not). Therefore, we need to look at the
+    // aria-disabled attribute instead.
     expect(button).toHaveAttribute('aria-disabled', 'true');
-    // Should show spinner element
+    // Should show a spinning icon.
     expect(button.querySelector('.icon-spin')).toBeInTheDocument();
   });
 
@@ -87,13 +97,12 @@ describe('AccountDetailsSubmitButton', () => {
       formIsValid: true,
       submissionIsPending: false,
       submissionIsSuccess: true,
+      submissionIsError: false,
     });
     const button = screen.getByTestId('stepper-submit-button');
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('Submitted');
-    expect(button).toHaveAttribute('aria-disabled', 'true');
-    // Should show check icon (CheckCircleOutline)
-    expect(button.querySelector('svg')).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
   });
 
   it('prioritizes complete state over invalid form', () => {
@@ -101,12 +110,24 @@ describe('AccountDetailsSubmitButton', () => {
       formIsValid: false,
       submissionIsPending: false,
       submissionIsSuccess: true,
+      submissionIsError: false,
     });
     const button = screen.getByTestId('stepper-submit-button');
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('Submitted');
-    expect(button).toHaveAttribute('aria-disabled', 'true');
-    // Should show check icon (CheckCircleOutline)
-    expect(button.querySelector('svg')).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it('renders the error state', () => {
+    setup({
+      formIsValid: true,
+      submissionIsPending: false,
+      submissionIsSuccess: false,
+      submissionIsError: true,
+    });
+    const button = screen.getByTestId('stepper-submit-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Try Again');
+    expect(button).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
Support the following cases:
1. click Continue -> nav to BillingDetails -> click Back -> click Continue
    * This case should NOT cause the mutation to run, which is blocked by its own isSuccess=true state.
2. click Continue -> nav to BillingDetails -> click Back -> update fields -> click Continue
    * This case should cause the mutation to run, and is supported by the new useEffect to reset the mutation.
3. click Continue -> API error -> update fields -> click Continue
    * This case should cause the mutation to run, and result in the StatefulButton transitioning back to the `default` state to allow retry.

Demo recording for testing all cases:

https://github.com/user-attachments/assets/f0026c9f-b2c8-4327-876b-ea7b8d066f3d
