### PR TITLE
chore: update validation message for invalid slug

### DIFF
--- a/src/components/app/data/services/tests/validation.test.ts
+++ b/src/components/app/data/services/tests/validation.test.ts
@@ -182,7 +182,7 @@ describe('fetchCheckoutValidation', () => {
     // Setup
     const invalidSlugError: ValidationDecision = validationDecisionFactory({
       errorCode: 'invalid_format',
-      developerMessage: 'Enterprise slug can only contain lowercase letters, numbers, and hyphens.',
+      developerMessage: 'Only alphanumeric lowercase characters and hyphens are allowed.',
     });
 
     const invalidQuantityError: ValidationDecision = validationDecisionFactory({
@@ -207,7 +207,7 @@ describe('fetchCheckoutValidation', () => {
     verifyValidationDecision(
       result.validationDecisions.enterpriseSlug as ValidationDecision,
       'invalid_format',
-      /lowercase letters, numbers, and hyphens/i,
+      /Only alphanumeric lowercase characters and hyphens are allowed./i,
     );
 
     expect(result.validationDecisions).toHaveProperty('quantity');
@@ -227,7 +227,7 @@ describe('fetchCheckoutValidation', () => {
       }),
       enterpriseSlug: validationDecisionFactory({
         errorCode: 'invalid_format',
-        developerMessage: 'Enterprise slug can only contain lowercase letters, numbers, and hyphens.',
+        developerMessage: 'Only alphanumeric lowercase characters and hyphens are allowed.',
       }),
       quantity: validationDecisionFactory({
         errorCode: 'invalid_range',
@@ -260,7 +260,7 @@ describe('fetchCheckoutValidation', () => {
     verifyValidationDecision(
       result.validationDecisions.enterpriseSlug as ValidationDecision,
       'invalid_format',
-      /lowercase letters, numbers, and hyphens/i,
+      /Only alphanumeric lowercase characters and hyphens/i,
     );
 
     verifyValidationDecision(

--- a/src/constants/checkout.ts
+++ b/src/constants/checkout.ts
@@ -39,7 +39,7 @@ export const CheckoutErrorMessagesByField: { [K in keyof FieldErrorCodes]: Recor
     incomplete_data: 'Not enough parameters were given.',
   },
   enterpriseSlug: {
-    invalid_format: 'Invalid format for given slug.',
+    invalid_format: 'Only alphanumeric lowercase characters and hyphens are allowed.',
     // EXISTING_ENTERPRISE_CUSTOMER_FOR_ADMIN uses the same error code on the backend
     existing_enterprise_customer: 'The slug conflicts with an existing customer.',
     slug_reserved: 'The slug is currently reserved by another user.',
@@ -130,7 +130,7 @@ export const AccountDetailsSchema = (constraints: CheckoutContextFieldConstraint
     )
     .regex(
       new RegExp(constraints?.enterpriseSlug?.pattern),
-      'Only lowercase letters, numbers, and hyphens allowed',
+      'Only alphanumeric lowercase characters and hyphens are allowed.',
     ),
 }));
 


### PR DESCRIPTION
Verified validation patterns on frontend and backend.
All patterns match `/^[a-z0-9-]+$/`.

Updated validation message to: `Only lowercase letters, numbers, and hyphens allowed.`

