### PR TITLE
fix: persist quantity

### DIFF
--- a/src/components/app/routes/loaders/utils.ts
+++ b/src/components/app/routes/loaders/utils.ts
@@ -84,6 +84,9 @@ const populateCompletedFormFields = ({
         ...s.formData,
         [DataStoreKey.PlanDetails]: {
           ...s.formData[DataStoreKey.PlanDetails],
+          quantity: s.formData[DataStoreKey.PlanDetails]?.quantity
+            ?? checkoutIntent?.quantity
+            ?? 0,
           fullName: s.formData[DataStoreKey.PlanDetails]?.fullName
             ?? authenticatedUser.name
             ?? authenticatedUser.username,

--- a/src/components/app/routes/tests/utils.test.ts
+++ b/src/components/app/routes/tests/utils.test.ts
@@ -136,6 +136,96 @@ describe('utils.ts', () => {
         }),
       );
     });
+
+    it('uses quantity from checkoutIntent when no existing form data quantity exists', () => {
+      const initialState = {
+        formData: {
+          [DataStoreKey.PlanDetails]: {}, // no quantity in existing form data
+          [DataStoreKey.AccountDetails]: {},
+          [DataStoreKey.BillingDetails]: {},
+        },
+      } as any;
+
+      const authenticatedUser: AuthenticatedUser = {
+        email: 'user@example.com',
+        name: 'Test User',
+        username: 'testuser',
+        country: 'US',
+      };
+
+      const checkoutIntent = {
+        state: 'created',
+        quantity: 25, // quantity should come from here
+        enterpriseSlug: 'test-company',
+        enterpriseName: 'Test Company Inc',
+      } satisfies TestCheckoutIntent;
+
+      const stripePriceId = faker.string.uuid();
+
+      populateCompletedFormFields({
+        checkoutIntent: checkoutIntent as CheckoutContextCheckoutIntent,
+        authenticatedUser,
+        stripePriceId,
+      });
+
+      expect((checkoutFormStore.setState as jest.Mock)).toHaveBeenCalled();
+      const [updater] = (checkoutFormStore.setState as jest.Mock).mock.calls[0];
+      const computed = updater(initialState);
+
+      expect(computed.formData[DataStoreKey.PlanDetails]).toEqual(
+        expect.objectContaining({
+          quantity: 25, // should come from checkoutIntent
+          fullName: 'Test User',
+          adminEmail: 'user@example.com',
+          country: 'US',
+        }),
+      );
+    });
+
+    it('defaults quantity to 0 when neither form data nor checkoutIntent have quantity', () => {
+      const initialState = {
+        formData: {
+          [DataStoreKey.PlanDetails]: {}, // no quantity in existing form data
+          [DataStoreKey.AccountDetails]: {},
+          [DataStoreKey.BillingDetails]: {},
+        },
+      } as any;
+
+      const authenticatedUser: AuthenticatedUser = {
+        email: 'user@example.com',
+        name: 'Test User',
+        username: 'testuser',
+        country: 'US',
+      };
+
+      const checkoutIntent = {
+        state: 'created',
+        // no quantity in checkoutIntent
+        enterpriseSlug: 'test-company',
+        enterpriseName: 'Test Company Inc',
+      } satisfies TestCheckoutIntent;
+
+      const stripePriceId = faker.string.uuid();
+
+      populateCompletedFormFields({
+        checkoutIntent: checkoutIntent as CheckoutContextCheckoutIntent,
+        authenticatedUser,
+        stripePriceId,
+      });
+
+      expect((checkoutFormStore.setState as jest.Mock)).toHaveBeenCalled();
+      const [updater] = (checkoutFormStore.setState as jest.Mock).mock.calls[0];
+      const computed = updater(initialState);
+
+      expect(computed.formData[DataStoreKey.PlanDetails]).toEqual(
+        expect.objectContaining({
+          quantity: 0, // should default to 0
+          fullName: 'Test User',
+          adminEmail: 'user@example.com',
+          country: 'US',
+        }),
+      );
+    });
   });
 
   describe('validateFormState', () => {

--- a/src/components/app/routes/tests/utils.test.ts
+++ b/src/components/app/routes/tests/utils.test.ts
@@ -25,6 +25,7 @@ jest.mock('@/hooks/useCheckoutFormStore', () => ({
 // Helper types for test inputs (loosely typed to avoid coupling to app types)
 type TestCheckoutIntent = {
   state: string;
+  quantity?: number;
   expiresAt?: string;
   enterpriseSlug?: string;
   enterpriseName?: string;


### PR DESCRIPTION
This pull request improves how the `quantity` field is populated in the checkout form, ensuring it is set correctly based on available data, and adds tests to verify the new logic. The changes enhance the reliability of form initialization during the checkout process.

**Checkout form field population:**

* Updated `populateCompletedFormFields` in `utils.ts` to set the `quantity` field in `PlanDetails` by checking, in order: existing form data, `checkoutIntent`, and finally defaulting to 0 if neither is present.

**Test coverage:**

* Added tests in `utils.test.ts` to verify that `quantity` is correctly sourced from `checkoutIntent` when missing in form data, and defaults to 0 when absent in both.