### PR TITLE
feat: navigate to registration on unregistered email

### DIFF
--- a/src/components/FormFields/RegisterAccountFields.tsx
+++ b/src/components/FormFields/RegisterAccountFields.tsx
@@ -1,6 +1,7 @@
-import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { FieldContainer } from '@/components/FieldContainer';
+import Field from '@/components/FormFields/Field';
 
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -10,26 +11,40 @@ interface RegisterAccountFieldsProps {
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const RegisterAccountFields = ({ form }: RegisterAccountFieldsProps) => (
-  <FieldContainer>
-    <div>
-      <h3>
-        <FormattedMessage
-          id="checkout.registerAccountField.title"
-          defaultMessage="Register your edX account to start the trial"
-          description="Title for the register account section"
-        />
-      </h3>
-      <h3 className="font-weight-light">
-        <FormattedMessage
-          id="checkout.registerAccountField.description"
-          defaultMessage="Your edX learner account will be granted administrator
+const RegisterAccountFields = ({ form }: RegisterAccountFieldsProps) => {
+  const intl = useIntl();
+  return (
+    <FieldContainer>
+      <div>
+        <h3>
+          <FormattedMessage
+            id="checkout.registerAccountField.title"
+            defaultMessage="Register your edX account to start the trial"
+            description="Title for the register account section"
+          />
+        </h3>
+        <h3 className="font-weight-light">
+          <FormattedMessage
+            id="checkout.registerAccountField.description"
+            defaultMessage="Your edX learner account will be granted administrator
            access to manage your organization's subscription when the trial starts."
-          description="Description text explaining the register account purpose"
-        />
-      </h3>
-    </div>
-  </FieldContainer>
-);
+            description="Description text explaining the register account purpose"
+          />
+        </h3>
+      </div>
+      <Field
+        form={form}
+        name="adminEmail"
+        type="email"
+        floatingLabel={intl.formatMessage({
+          id: 'checkout.nameAndEmailFields.companyName.floatingLabel',
+          defaultMessage: 'Company Name',
+          description: 'Floating label for the company name input field',
+        })}
+      />
+
+    </FieldContainer>
+  );
+};
 
 export default RegisterAccountFields;

--- a/src/components/app/data/services/validation.ts
+++ b/src/components/app/data/services/validation.ts
@@ -148,9 +148,10 @@ export function validateFieldDetailed<K extends FieldKey>(
   field: K,
   value: ValidationSchema[K],
   extras?: Partial<ValidationSchema>,
+  overridePrevious: Boolean = false,
 ): Promise<{ isValid: boolean; validationDecisions: ValidationResponse['validationDecisions'] | null }> {
   const current = { value, extras: extras ?? {} };
-  if (isEqual(previousValues.get(field), current)) {
+  if (!overridePrevious && isEqual(previousValues.get(field), current)) {
     // Treat unchanged value as valid and with no new decisions
     return Promise.resolve({ isValid: true, validationDecisions: {} });
   }


### PR DESCRIPTION
This pull request introduces significant improvements to the registration and plan details flow, particularly around the handling and validation of the `adminEmail` field. The changes ensure that the system can differentiate between registered and unregistered emails, enabling a more precise user navigation experience between login and registration pages. Additionally, the validation logic is enhanced to allow for asynchronous checks and more granular error handling.

**Key changes include:**

### Registration and Form Field Enhancements

* Added a new `Field` component for the `adminEmail` input in `RegisterAccountFields`, using internationalized floating labels for better usability. [[1]](diffhunk://#diff-b06ddc4a56c8d30c5a09025fcd70a84508190794c237efa3ecc31f154fedb2deL1-R4) [[2]](diffhunk://#diff-b06ddc4a56c8d30c5a09025fcd70a84508190794c237efa3ecc31f154fedb2deL13-R16) [[3]](diffhunk://#diff-b06ddc4a56c8d30c5a09025fcd70a84508190794c237efa3ecc31f154fedb2deR35-R48)

### Validation Logic Improvements

* Updated `validateFieldDetailed` to accept an `overridePrevious` parameter, allowing forced re-validation even if the value hasn't changed.
* Enhanced the `PlanDetailsSchema` to use an asynchronous `superRefine` for `adminEmail`, which now only throws a validation error for error codes other than `not_registered`, deferring navigation decisions to the submit callback.

### Plan Details Submission Flow

* Modified the plan details submission handler to asynchronously validate `adminEmail` and navigate users to either the registration or login page based on whether the email is registered, using the new validation decisions.
* Ensured that the `queryClientInvalidate` call in the checkout intent mutation is awaited, improving consistency in navigation after checkout intent creation.

### Dependency and Import Updates

* Imported `validateFieldDetailed` into the plan details page to support the new validation logic.