### PR TITLE
feat: Added Essentials for billing success page

### DIFF
--- a/src/components/Stepper/StepperContent/tests/BillingDetailsSuccessContent.test.tsx
+++ b/src/components/Stepper/StepperContent/tests/BillingDetailsSuccessContent.test.tsx
@@ -104,13 +104,15 @@ describe('BillingDetailsSuccessContent', () => {
   });
 
   it('renders BillingDetailsHeadingMessage, StatefulProvisioningButton and OrderDetails by default', () => {
+    // Set session to Teams flow (not Essentials)
+    sessionStorage.removeItem('isEssentials');
     renderComponent();
 
     // BillingDetailsHeadingMessage renders with celebration image
     expect(screen.getByAltText('Celebration of subscription purchase success')).toBeInTheDocument();
     // OrderDetails renders its content
     validateText('Order details');
-    validateText('You have purchased an edX team\'s subscription.');
+    validateText('You have purchased an edX Team subscription.');
   });
 
   it('renders PendingHeading when checkout intent state is "paid"', () => {
@@ -128,7 +130,7 @@ describe('BillingDetailsSuccessContent', () => {
 
     renderComponent();
 
-    validateText(/Welcome to edX for Teams! Your account is currently being configured/);
+    validateText(/Welcome to edX for Team! Your account is currently being configured/);
     expect(screen.getByAltText('Celebration of subscription purchase success')).toBeInTheDocument();
     expect(screen.queryByText('We\'re sorry, something went wrong')).not.toBeInTheDocument();
   });
@@ -148,9 +150,9 @@ describe('BillingDetailsSuccessContent', () => {
 
     renderComponent();
 
-    validateText(/Welcome to edX for Teams!/);
+    validateText(/Welcome to edX for Team/);
     expect(screen.getByAltText('Celebration of subscription purchase success')).toBeInTheDocument();
-    expect(screen.queryByText('We\'re sorry, something went wrong')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Welcome to edX for Teams!/)).not.toBeInTheDocument();
   });
 
   it.each([
@@ -173,7 +175,7 @@ describe('BillingDetailsSuccessContent', () => {
     renderComponent();
 
     validateText('Account Setup is Taking Longer Than Expected');
-    validateText("We're experiencing a brief delay in setting up your edX Teams account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!");
-    expect(screen.queryByText(/Welcome to edX for Teams!/)).not.toBeInTheDocument();
+    validateText("We're experiencing a brief delay in setting up your edX Team account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!");
+    expect(screen.queryByText(/Welcome to edX for Team/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/Stepper/StepperContent/tests/BillingDetailsSuccessContent.test.tsx
+++ b/src/components/Stepper/StepperContent/tests/BillingDetailsSuccessContent.test.tsx
@@ -70,6 +70,8 @@ describe('BillingDetailsSuccessContent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset sessionStorage between tests
+    sessionStorage.clear();
 
     // Set default mock values for all hooks
     (mockUseBFFSuccess as jest.Mock).mockReturnValue({
@@ -113,6 +115,18 @@ describe('BillingDetailsSuccessContent', () => {
     // OrderDetails renders its content
     validateText('Order details');
     validateText('You have purchased an edX Team subscription.');
+  });
+
+  it('renders Essentials-specific content when isEssentials is set', () => {
+    // Set session to Essentials flow
+    sessionStorage.setItem('isEssentials', 'true');
+    renderComponent();
+
+    // BillingDetailsHeadingMessage renders with celebration image
+    expect(screen.getByAltText('Celebration of subscription purchase success')).toBeInTheDocument();
+    // OrderDetails renders Essentials-specific content
+    validateText('Order details');
+    validateText('You have purchased an edX Essentials subscription.');
   });
 
   it('renders PendingHeading when checkout intent state is "paid"', () => {

--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
@@ -11,7 +11,11 @@ const ErrorHeading = () => {
   return (
     <>
       <h2 className="text-center font-weight-normal mb-0">
-        Account Setup is Taking Longer Than Expected
+        <FormattedMessage
+          id="checkout.success.error.heading"
+          defaultMessage="Account Setup is Taking Longer Than Expected"
+          description="Heading text for delayed account setup"
+        />
       </h2>
       <p className="h4 font-weight-light text-center">
         <FormattedMessage

--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
@@ -16,8 +16,11 @@ const ErrorHeading = () => {
       <p className="h4 font-weight-light text-center">
         <FormattedMessage
           id="checkout.success.error.description"
-          defaultMessage={isEssentials ? "We're experiencing a brief delay in setting up your edX Essentials account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!" : "We're experiencing a brief delay in setting up your edX Team account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!"}
+          defaultMessage="We're experiencing a brief delay in setting up your {productName} account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!"
           description="Description text explaining the error account setup status"
+          values={{
+            productName: isEssentials ? 'edX Essentials' : 'edX Team',
+          }}
         />
       </p>
     </>
@@ -30,8 +33,11 @@ const InactiveUserHeading = () => {
     <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
         id="checkout.success.inactive.description"
-        defaultMessage={isEssentials ? 'Welcome to edX for Essentials! Please check your email to complete the account confirmation process.' : 'Welcome to edX for Team! Please check your email to complete the account confirmation process.'}
+        defaultMessage="Welcome to {productName}! Please check your email to complete the account confirmation process."
         description="Description text explaining that user needs to verify their email"
+        values={{
+          productName: isEssentials ? 'edX for Essentials' : 'edX for Team',
+        }}
       />
     </p>
   );
@@ -43,8 +49,11 @@ const PendingHeading = () => {
     <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
         id="checkout.success.pending.description"
-        defaultMessage={isEssentials ? "Welcome to edX for Essentials! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning." : "Welcome to edX for Team! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning."}
+        defaultMessage="Welcome to {productName}! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning."
         description="Description text explaining the pending account setup status"
+        values={{
+          productName: isEssentials ? 'edX for Essentials' : 'edX for Team',
+        }}
       />
     </p>
   );
@@ -56,8 +65,11 @@ const SuccessHeading = () => {
     <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
         id="checkout.success.default.description"
-        defaultMessage={isEssentials ? 'Welcome to edX for Essentials! Go to your administrator dashboard to onboard and invite your team members to start learning.' : 'Welcome to edX for Team! Go to your administrator dashboard to onboard and invite your team members to start learning.'}
+        defaultMessage="Welcome to {productName}! Go to your administrator dashboard to onboard and invite your team members to start learning."
         description="Description text explaining the success account setup status"
+        values={{
+          productName: isEssentials ? 'edX for Essentials' : 'edX for Team',
+        }}
       />
     </p>
   );

--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
@@ -2,53 +2,66 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Container, Image, Stack } from '@openedx/paragon';
 
 import { usePolledAuthenticatedUser, usePolledCheckoutIntent } from '@/components/app/data';
+import { isEssentialsFlow } from '@/components/app/routes/loaders/utils';
 
 import Celebration from './images/celebration.svg';
 
-const ErrorHeading = () => (
-  <>
-    <h2 className="text-center font-weight-normal mb-0">
-      Account Setup is Taking Longer Than Expected
-    </h2>
-    <p className="h4 font-weight-light text-center">
+const ErrorHeading = () => {
+  const isEssentials = isEssentialsFlow();
+  return (
+    <>
+      <h2 className="text-center font-weight-normal mb-0">
+        Account Setup is Taking Longer Than Expected
+      </h2>
+      <p className="h4 font-weight-light text-center">
+        <FormattedMessage
+          id="checkout.success.error.description"
+          defaultMessage={isEssentials ? "We're experiencing a brief delay in setting up your edX Essentials account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!" : "We're experiencing a brief delay in setting up your edX Team account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!"}
+          description="Description text explaining the error account setup status"
+        />
+      </p>
+    </>
+  );
+};
+
+const InactiveUserHeading = () => {
+  const isEssentials = isEssentialsFlow();
+  return (
+    <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
-        id="checkout.success.error.description"
-        defaultMessage="We're experiencing a brief delay in setting up your edX Teams account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!"
-        description="Description text explaining the error account setup status"
+        id="checkout.success.inactive.description"
+        defaultMessage={isEssentials ? 'Welcome to edX for Essentials! Please check your email to complete the account confirmation process.' : 'Welcome to edX for Team! Please check your email to complete the account confirmation process.'}
+        description="Description text explaining that user needs to verify their email"
       />
     </p>
-  </>
-);
+  );
+};
 
-const InactiveUserHeading = () => (
-  <p className="fs-4 font-weight-light text-center">
-    <FormattedMessage
-      id="checkout.success.inactive.description"
-      defaultMessage="Welcome to edX for Teams! Please check your email to complete the account confirmation process."
-      description="Description text explaining that user needs to verify their email"
-    />
-  </p>
-);
+const PendingHeading = () => {
+  const isEssentials = isEssentialsFlow();
+  return (
+    <p className="fs-4 font-weight-light text-center">
+      <FormattedMessage
+        id="checkout.success.pending.description"
+        defaultMessage={isEssentials ? "Welcome to edX for Essentials! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning." : "Welcome to edX for Team! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning."}
+        description="Description text explaining the pending account setup status"
+      />
+    </p>
+  );
+};
 
-const PendingHeading = () => (
-  <p className="fs-4 font-weight-light text-center">
-    <FormattedMessage
-      id="checkout.success.pending.description"
-      defaultMessage="Welcome to edX for Teams! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning."
-      description="Description text explaining the pending account setup status"
-    />
-  </p>
-);
-
-const SuccessHeading = () => (
-  <p className="fs-4 font-weight-light text-center">
-    <FormattedMessage
-      id="checkout.success.default.description"
-      defaultMessage="Welcome to edX for Teams! Go to your administrator dashboard to onboard and invite your team members to start learning."
-      description="Description text explaining the success account setup status"
-    />
-  </p>
-);
+const SuccessHeading = () => {
+  const isEssentials = isEssentialsFlow();
+  return (
+    <p className="fs-4 font-weight-light text-center">
+      <FormattedMessage
+        id="checkout.success.default.description"
+        defaultMessage={isEssentials ? 'Welcome to edX for Essentials! Go to your administrator dashboard to onboard and invite your team members to start learning.' : 'Welcome to edX for Team! Go to your administrator dashboard to onboard and invite your team members to start learning.'}
+        description="Description text explaining the success account setup status"
+      />
+    </p>
+  );
+};
 
 const determineBannerMessageElement = (
   checkoutIntentState?: string | null,
@@ -61,21 +74,23 @@ const determineBannerMessageElement = (
     return <InactiveUserHeading />;
   }
 
-  if (checkoutIntentState === 'paid') {
-    return <PendingHeading />;
-  }
-
+  // Show success message for fulfilled state
   if (checkoutIntentState === 'fulfilled') {
     return <SuccessHeading />;
   }
 
+  // Show pending message for paid or created states (account setup in progress)
+  if (checkoutIntentState === 'paid' || checkoutIntentState === 'created') {
+    return <PendingHeading />;
+  }
+
+  // Show error message for any error states
   return <ErrorHeading />;
 };
 
 const BillingDetailsHeadingMessage = () => {
   const { polledCheckoutIntent } = usePolledCheckoutIntent();
   const { polledAuthenticatedUser } = usePolledAuthenticatedUser();
-
   const bannerMessageElement = determineBannerMessageElement(
     polledCheckoutIntent?.state,
     polledAuthenticatedUser?.isActive,

--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/tests/BillingDetailsHeadingMessage.test.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/tests/BillingDetailsHeadingMessage.test.tsx
@@ -53,7 +53,7 @@ describe('BillingDetailsHeadingMessage', () => {
     } as any);
 
     renderComponent();
-    expect(screen.getByText(/Welcome to edX for Teams!/)).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to edX for Team/)).toBeInTheDocument();
     expect(screen.getByText(/Go to your administrator dashboard/)).toBeInTheDocument();
   });
 
@@ -66,7 +66,7 @@ describe('BillingDetailsHeadingMessage', () => {
     } as any);
 
     renderComponent();
-    expect(screen.getByText(/Welcome to edX for Teams!/)).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to edX for Team/)).toBeInTheDocument();
     expect(screen.getByText(/Your account is currently being configured/)).toBeInTheDocument();
   });
 

--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/tests/BillingDetailsHeadingMessage.test.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/tests/BillingDetailsHeadingMessage.test.tsx
@@ -70,6 +70,19 @@ describe('BillingDetailsHeadingMessage', () => {
     expect(screen.getByText(/Your account is currently being configured/)).toBeInTheDocument();
   });
 
+  it('renders PendingHeading when checkout is created and user is active', () => {
+    mockUsePolledCheckoutIntent.mockReturnValue({
+      polledCheckoutIntent: { state: 'created' },
+    } as any);
+    mockUsePolledAuthenticatedUser.mockReturnValue({
+      polledAuthenticatedUser: { isActive: true },
+    } as any);
+
+    renderComponent();
+    expect(screen.getByText(/Welcome to edX for Team/)).toBeInTheDocument();
+    expect(screen.getByText(/Your account is currently being configured/)).toBeInTheDocument();
+  });
+
   it('renders ErrorHeading when checkout is errored and user is active', () => {
     mockUsePolledCheckoutIntent.mockReturnValue({
       polledCheckoutIntent: { state: 'errored_provisioning' },
@@ -119,7 +132,8 @@ describe('BillingDetailsHeadingMessage', () => {
     renderComponent();
     // Should only render the image, no heading text
     expect(screen.getByRole('img')).toBeInTheDocument();
-    expect(screen.queryByText(/Welcome to edX for Teams!/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Go to your administrator dashboard/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Your account is currently being configured/)).not.toBeInTheDocument();
   });
 
   it('renders nothing when checkout intent is undefined', () => {
@@ -133,6 +147,7 @@ describe('BillingDetailsHeadingMessage', () => {
     renderComponent();
     // Should only render the image, no heading text
     expect(screen.getByRole('img')).toBeInTheDocument();
-    expect(screen.queryByText(/Welcome to edX for Teams!/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Go to your administrator dashboard/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Your account is currently being configured/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/billing-details-pages/OrderDetails/OrderDetailsBillingInfo.tsx
+++ b/src/components/billing-details-pages/OrderDetails/OrderDetailsBillingInfo.tsx
@@ -3,6 +3,7 @@ import { Col, Row, Stack } from '@openedx/paragon';
 import { capitalize } from 'lodash-es';
 
 import { useFirstBillableInvoice } from '@/components/app/data';
+import { isEssentialsFlow } from '@/components/app/routes/loaders/utils';
 import { DataStoreKey } from '@/constants/checkout';
 import { useCheckoutFormStore } from '@/hooks/useCheckoutFormStore';
 
@@ -10,6 +11,7 @@ const OrderDetailsBillingInfo = () => {
   const { data: firstBillableInvoice } = useFirstBillableInvoice();
   const planDetailsData = useCheckoutFormStore((state) => state.formData[DataStoreKey.PlanDetails]);
   const { adminEmail } = planDetailsData;
+  const isEssentials = isEssentialsFlow();
 
   if (!firstBillableInvoice) {
     return null;
@@ -26,8 +28,25 @@ const OrderDetailsBillingInfo = () => {
 
   return (
     <>
-      <Row>
-        <Col xs={12} md={6} className="mb-4">
+      {/* Academy Name - Essentials only */}
+      {isEssentials && (
+        <Row className="mb-4">
+          <Col xs={12}>
+            <h3 className="h5 mb-2">
+              <FormattedMessage
+                id="checkout.orderDetails.academyName"
+                defaultMessage="Academy Name"
+                description="Label for academy name section"
+              />
+            </h3>
+            <p className="text-muted mb-0">—</p>
+          </Col>
+        </Row>
+      )}
+
+      {/* Admin Contact and Payment Method */}
+      <Row className="mb-4">
+        <Col xs={12} md={6} className="mb-4 mb-md-0">
           <h3 className="h5 mb-2">
             <FormattedMessage
               id="checkout.orderDetails.adminContactInfo"
@@ -37,7 +56,7 @@ const OrderDetailsBillingInfo = () => {
           </h3>
           <p className="text-muted mb-0">{adminEmail}</p>
         </Col>
-        <Col xs={12} md={6} className="mb-4">
+        <Col xs={12} md={6}>
           <h3 className="h5 mb-2">
             <FormattedMessage
               id="checkout.orderDetails.paymentMethod"
@@ -59,9 +78,9 @@ const OrderDetailsBillingInfo = () => {
             </span>
           </div>
         </Col>
-
       </Row>
 
+      {/* Billing Address */}
       <div className="mb-4">
         <h3 className="h5 mb-2">
           <FormattedMessage

--- a/src/components/billing-details-pages/OrderDetails/OrderDetailsHeading.tsx
+++ b/src/components/billing-details-pages/OrderDetails/OrderDetailsHeading.tsx
@@ -16,8 +16,11 @@ const OrderDetailsHeading: React.FC = () => {
       <p className="fs-4 text-muted mb-3 font-weight-light">
         <FormattedMessage
           id="checkout.orderDetails.description"
-          defaultMessage={isEssentials ? 'You have purchased an edX Essentials subscription.' : 'You have purchased an edX Team subscription.'}
+          defaultMessage="You have purchased an edX {productName} subscription."
           description="Description text explaining the order details"
+          values={{
+            productName: isEssentials ? 'Essentials' : 'Team',
+          }}
         />
       </p>
     </>

--- a/src/components/billing-details-pages/OrderDetails/OrderDetailsHeading.tsx
+++ b/src/components/billing-details-pages/OrderDetails/OrderDetailsHeading.tsx
@@ -1,22 +1,27 @@
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
-const OrderDetailsHeading: React.FC = () => (
-  <>
-    <h3 className="mb-2">
-      <FormattedMessage
-        id="checkout.orderDetails.title"
-        defaultMessage="Order details"
-        description="Title for the order details section"
-      />
-    </h3>
-    <p className="fs-4 text-muted mb-3 font-weight-light">
-      <FormattedMessage
-        id="checkout.orderDetails.description"
-        defaultMessage="You have purchased an edX team's subscription."
-        description="Description text explaining the order details"
-      />
-    </p>
-  </>
-);
+import { isEssentialsFlow } from '@/components/app/routes/loaders/utils';
+
+const OrderDetailsHeading: React.FC = () => {
+  const isEssentials = isEssentialsFlow();
+  return (
+    <>
+      <h3 className="mb-2">
+        <FormattedMessage
+          id="checkout.orderDetails.title"
+          defaultMessage="Order details"
+          description="Title for the order details section"
+        />
+      </h3>
+      <p className="fs-4 text-muted mb-3 font-weight-light">
+        <FormattedMessage
+          id="checkout.orderDetails.description"
+          defaultMessage={isEssentials ? 'You have purchased an edX Essentials subscription.' : 'You have purchased an edX Team subscription.'}
+          description="Description text explaining the order details"
+        />
+      </p>
+    </>
+  );
+};
 
 export default OrderDetailsHeading;

--- a/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
+++ b/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
@@ -148,7 +148,6 @@ describe('OrderDetails', () => {
     });
   });
 
-
   describe('Admin contact information', () => {
     it('displays admin email from plan details form data', () => {
       (useFirstBillableInvoice as jest.Mock).mockReturnValue({

--- a/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
+++ b/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
@@ -112,6 +112,16 @@ describe('OrderDetails', () => {
   );
 
   describe('Basic rendering', () => {
+    it('returns null when firstBillableInvoice data is not available', () => {
+      (useFirstBillableInvoice as jest.Mock).mockReturnValue({
+        data: null,
+        isLoading: false,
+      });
+
+      const { container } = renderComponent();
+      expect(container.firstChild).toBeNull();
+    });
+
     it.each([
       ['the title', 'Order details'],
       ['the description', 'You have purchased an edX Team subscription.'],
@@ -137,6 +147,7 @@ describe('OrderDetails', () => {
       validateText('Billing address');
     });
   });
+
 
   describe('Admin contact information', () => {
     it('displays admin email from plan details form data', () => {

--- a/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
+++ b/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
@@ -27,6 +27,11 @@ jest.mock('@/utils/common', () => ({
   sendEnterpriseCheckoutTrackingEvent: jest.fn(),
 }));
 
+jest.mock('@/components/app/routes/loaders/utils', () => ({
+  ...jest.requireActual('@/components/app/routes/loaders/utils'),
+  isEssentialsFlow: jest.fn(() => false),
+}));
+
 const { useFirstBillableInvoice, useCheckoutIntent } = jest.requireMock('@/components/app/data');
 
 describe('OrderDetails', () => {
@@ -347,6 +352,43 @@ describe('OrderDetails', () => {
         checkoutIntentId: mockCheckoutIntentId,
         eventName: EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CONTACT_SUPPORT_LINK_CLICKED,
       });
+    });
+  });
+
+  describe('Academy Name (Essentials flow)', () => {
+    it('displays Academy Name label with placeholder dash when in Essentials flow', () => {
+      const { isEssentialsFlow } = jest.requireMock('@/components/app/routes/loaders/utils');
+      (isEssentialsFlow as jest.Mock).mockReturnValue(true);
+
+      (useFirstBillableInvoice as jest.Mock).mockReturnValue({
+        data: {
+          last4: mockLast4,
+          cardBrand: 'visa',
+          hasCardDetails: true,
+        },
+        isLoading: false,
+      });
+
+      renderComponent();
+      validateText('Academy Name');
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
+    it('does not display Academy Name section when not in Essentials flow', () => {
+      const { isEssentialsFlow } = jest.requireMock('@/components/app/routes/loaders/utils');
+      (isEssentialsFlow as jest.Mock).mockReturnValue(false);
+
+      (useFirstBillableInvoice as jest.Mock).mockReturnValue({
+        data: {
+          last4: mockLast4,
+          cardBrand: 'visa',
+          hasCardDetails: true,
+        },
+        isLoading: false,
+      });
+
+      renderComponent();
+      expect(screen.queryByText('Academy Name')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
+++ b/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
@@ -109,7 +109,7 @@ describe('OrderDetails', () => {
   describe('Basic rendering', () => {
     it.each([
       ['the title', 'Order details'],
-      ['the description', "You have purchased an edX team's subscription."],
+      ['the description', 'You have purchased an edX Team subscription.'],
     ])('renders %s correctly', (_label, expectedText) => {
       renderComponent();
       validateText(expectedText);

--- a/src/components/billing-details-pages/SubscriptionStartMessage/SubscriptionStartMessage.tsx
+++ b/src/components/billing-details-pages/SubscriptionStartMessage/SubscriptionStartMessage.tsx
@@ -8,6 +8,7 @@ import {
   usePurchaseSummaryPricing,
 } from '@/components/app/data';
 import { LONG_MONTH_DATE_FORMAT, SUBSCRIPTION_TRIAL_LENGTH_DAYS } from '@/components/app/data/constants';
+import { isEssentialsFlow } from '@/components/app/routes/loaders/utils';
 import { DisplayPrice } from '@/components/DisplayPrice';
 import { FieldContainer } from '@/components/FieldContainer';
 import EVENT_NAMES from '@/constants/events';
@@ -27,6 +28,7 @@ const messages = defineMessages({
 
 const SubscriptionStartMessage = () => {
   const intl = useIntl();
+  const isEssentials = isEssentialsFlow();
   const { data: firstBillableInvoice, isLoading } = useFirstBillableInvoice();
   // TODO: Add this endpoint to the success page loader
   const { data: billingPortalSession } = useCreateBillingPortalSession();
@@ -53,7 +55,7 @@ const SubscriptionStartMessage = () => {
         <h3>
           <FormattedMessage
             id="checkout.freeTrialSubscriptionStartMessage.title"
-            defaultMessage="Your free {trialDays}-day trial for edX Team's subscription has started."
+            defaultMessage={isEssentials ? 'Your free {trialDays}-day trial for edX Essentials subscription has started.' : 'Your free {trialDays}-day trial for edX Team subscription has started.'}
             description="Title for the free trial success field section"
             values={{
               trialDays: SUBSCRIPTION_TRIAL_LENGTH_DAYS,

--- a/src/components/billing-details-pages/SubscriptionStartMessage/SubscriptionStartMessage.tsx
+++ b/src/components/billing-details-pages/SubscriptionStartMessage/SubscriptionStartMessage.tsx
@@ -55,10 +55,11 @@ const SubscriptionStartMessage = () => {
         <h3>
           <FormattedMessage
             id="checkout.freeTrialSubscriptionStartMessage.title"
-            defaultMessage={isEssentials ? 'Your free {trialDays}-day trial for edX Essentials subscription has started.' : 'Your free {trialDays}-day trial for edX Team subscription has started.'}
+            defaultMessage="Your free {trialDays}-day trial for {productName} subscription has started."
             description="Title for the free trial success field section"
             values={{
               trialDays: SUBSCRIPTION_TRIAL_LENGTH_DAYS,
+              productName: isEssentials ? 'edX Essentials' : 'edX Team',
             }}
           />
         </h3>

--- a/src/components/billing-details-pages/SubscriptionStartMessage/tests/SubscriptionStartMessage.test.tsx
+++ b/src/components/billing-details-pages/SubscriptionStartMessage/tests/SubscriptionStartMessage.test.tsx
@@ -65,7 +65,7 @@ describe('SubscriptionStartMessage', () => {
 
   it('renders the title correctly', () => {
     renderComponent();
-    validateText('Your free 14-day trial for edX Team\'s subscription has started.');
+    validateText('Your free 14-day trial for edX Team subscription has started.');
   });
 
   it('renders the description message correctly', () => {

--- a/src/components/billing-details-pages/SubscriptionStartMessage/tests/SubscriptionStartMessage.test.tsx
+++ b/src/components/billing-details-pages/SubscriptionStartMessage/tests/SubscriptionStartMessage.test.tsx
@@ -28,6 +28,8 @@ const mockUseFirstBillableInvoice = useFirstBillableInvoice as jest.MockedFuncti
 
 describe('SubscriptionStartMessage', () => {
   beforeEach(() => {
+    // Reset sessionStorage between tests
+    sessionStorage.clear();
     // Mock the hook to return data that will render "June 9th, 2025"
     (mockUseFirstBillableInvoice as jest.Mock).mockReturnValue({
       data: {
@@ -63,9 +65,15 @@ describe('SubscriptionStartMessage', () => {
     </IntlProvider>,
   );
 
-  it('renders the title correctly', () => {
+  it('renders the title correctly for Teams flow', () => {
     renderComponent();
     validateText('Your free 14-day trial for edX Team subscription has started.');
+  });
+
+  it('renders the title correctly for Essentials flow', () => {
+    sessionStorage.setItem('isEssentials', 'true');
+    renderComponent();
+    validateText('Your free 14-day trial for edX Essentials subscription has started.');
   });
 
   it('renders the description message correctly', () => {

--- a/src/components/billing-details-pages/tests/BillingDetailsPage.test.tsx
+++ b/src/components/billing-details-pages/tests/BillingDetailsPage.test.tsx
@@ -228,7 +228,7 @@ describe('BillingDetailsSuccessPage', () => {
       },
     });
     validateText('Order details');
-    validateText('You have purchased an edX team\'s subscription.');
+    validateText('You have purchased an edX Team subscription.');
   });
 
   it('renders the SuccessHeading component', async () => {
@@ -238,7 +238,7 @@ describe('BillingDetailsSuccessPage', () => {
         userId: 12345,
       },
     });
-    await waitFor(() => validateText((content) => content.includes('Welcome to edX for Teams!')));
+    await waitFor(() => validateText((content) => content.includes('Welcome to edX for Team')));
     expect(screen.getByAltText('Celebration of subscription purchase success')).toBeInTheDocument();
   });
 });

--- a/src/constants/checkout.ts
+++ b/src/constants/checkout.ts
@@ -279,10 +279,16 @@ export const BillingDetailsSchema = (constraints: CheckoutContextFieldConstraint
   })
 );
 
-// Simple empty schema - no validation needed for coming soon page
+// Schema for capturing academy name in Essentials flow
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const AcademicSelectionSchema = (constraints: CheckoutContextFieldConstraints) => (z.object({}));
+export const AcademicSelectionSchema = (constraints: CheckoutContextFieldConstraints) => (
+  z.object({
+    academyName: z.string().trim()
+      .min(1, 'Academy name is required')
+      .max(255, 'Academy name must be no more than 255 characters'),
+  })
+);
 
 export const CheckoutPageRoute = {
   PlanDetails: `/${CheckoutStepKey.PlanDetails}`,
@@ -422,6 +428,7 @@ export const authenticatedSteps = [
 ] as const;
 
 export enum DataStoreKey {
+  AcademySelection = 'AcademySelection',
   PlanDetails = 'PlanDetails',
   AccountDetails = 'AccountDetails',
   BillingDetails = 'BillingDetails',


### PR DESCRIPTION
**Ticket no.** : https://2u-internal.atlassian.net/browse/ENT-11448
**Description :**
Following the successful submission of billing details, the user must be directed to a confirmation page that acknowledges their subscription trial. This page serves as a transition point while backend processes—including Stripe validation, Salesforce record creation, and edX Enterprise provisioning—occur in the background.


<img width="728" height="348" alt="image" src="https://github.com/user-attachments/assets/8f214b1b-ca54-4cb0-a12e-4d6404421905" />
<img width="789" height="315" alt="image" src="https://github.com/user-attachments/assets/286edb96-21d8-4bba-98d6-800f936b9901" />
<img width="788" height="356" alt="image" src="https://github.com/user-attachments/assets/c82edfd1-ea2e-44ff-86b0-3e1f7064b105" />
<img width="642" height="335" alt="image" src="https://github.com/user-attachments/assets/702deecf-7cb7-4161-ba9d-846faf12ff5d" />

