### PR TITLE
feat: 11712/SSP-Essentials

### DIFF
--- a/src/components/Stepper/StepperContent/AccountDetailsContent.tsx
+++ b/src/components/Stepper/StepperContent/AccountDetailsContent.tsx
@@ -1,7 +1,9 @@
-import {
+import { AppContext } from '@edx/frontend-platform/react';
+import { useContext } from 'react';
+
+import { AuthenticatedUserField,
   CompanyNameField,
-  CustomUrlField,
-} from '@/components/FormFields';
+  CustomUrlField } from '@/components/FormFields';
 
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -9,11 +11,22 @@ interface AccountDetailsContentProps {
   form: UseFormReturn<AccountDetailsData>;
 }
 
-const AccountDetailsContent = ({ form }: AccountDetailsContentProps) => (
-  <>
-    <CompanyNameField form={form} />
-    <CustomUrlField form={form} />
-  </>
-);
+const AccountDetailsContent = ({ form }: AccountDetailsContentProps) => {
+  const { authenticatedUser }: AppContextValue = useContext(AppContext);
+
+  return (
+    <>
+      {authenticatedUser
+            && (
+              <AuthenticatedUserField
+                adminEmail={authenticatedUser.email}
+                fullName={authenticatedUser.name || authenticatedUser.username}
+              />
+            )}
+      <CompanyNameField form={form} />
+      <CustomUrlField form={form} />
+    </>
+  );
+};
 
 export default AccountDetailsContent;

--- a/src/components/app/routes/loaders/checkoutStepperLoader.ts
+++ b/src/components/app/routes/loaders/checkoutStepperLoader.ts
@@ -72,7 +72,7 @@ async function accountDetailsLoader(queryClient: QueryClient): Promise<Response 
     // If the user is NOT authenticated, redirect to PlanDetails Page.
     return redirect(CheckoutPageRoute.PlanDetails);
   }
-  
+
   const contextMetadata: CheckoutContextResponse = await queryClient.ensureQueryData(
     queryBffContext(authenticatedUser?.userId || null),
   );

--- a/src/components/app/routes/loaders/checkoutStepperLoader.ts
+++ b/src/components/app/routes/loaders/checkoutStepperLoader.ts
@@ -29,9 +29,9 @@ async function planDetailsLoginLoader(): Promise<Response | null> {
   if (redirectToPlanDetails || authenticatedUser) {
     // Redirect to PlanDetails if: (1) adminEmail is missing, or (2) user is already authenticated.
     if (isEssentialsFlow()) {
-      return redirect(EssentialsPageRoute.PlanDetails);
+      return redirect(EssentialsPageRoute.AccountDetails);
     }
-    return redirect(CheckoutPageRoute.PlanDetails);
+    return redirect(CheckoutPageRoute.AccountDetails);
   }
   return null;
 }
@@ -52,9 +52,9 @@ async function planDetailsRegisterLoader(): Promise<Response | null> {
   if (redirectToPlanDetails || authenticatedUser) {
     // Redirect to PlanDetails if: (1) required metadata is missing, or (2) user is already authenticated.
     if (isEssentialsFlow()) {
-      return redirect(EssentialsPageRoute.PlanDetails);
+      return redirect(EssentialsPageRoute.AccountDetails);
     }
-    return redirect(CheckoutPageRoute.PlanDetails);
+    return redirect(CheckoutPageRoute.AccountDetails);
   }
 
   return null;
@@ -72,7 +72,7 @@ async function accountDetailsLoader(queryClient: QueryClient): Promise<Response 
     // If the user is NOT authenticated, redirect to PlanDetails Page.
     return redirect(CheckoutPageRoute.PlanDetails);
   }
-
+  
   const contextMetadata: CheckoutContextResponse = await queryClient.ensureQueryData(
     queryBffContext(authenticatedUser?.userId || null),
   );

--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -199,6 +199,20 @@ const makeRootLoader = (
     return redirectOrNull(CheckoutPageRoute.PlanDetails);
   }
 
+  const postRegister = sessionStorage.getItem('postRegister') === 'true';
+
+  const isPlanDetails = currentPath === CheckoutPageRoute.PlanDetails
+  || currentPath === EssentialsPageRoute.PlanDetails;
+
+  if (authenticatedUser && postRegister && isPlanDetails) {
+    sessionStorage.removeItem('postRegister');
+    return redirectOrNull(
+      isEssentialsPath
+        ? EssentialsPageRoute.AccountDetails
+        : CheckoutPageRoute.AccountDetails,
+    );
+  }
+
   const { checkoutIntent, pricing } = contextMetadata;
 
   const {

--- a/src/components/app/routes/tests/checkoutStepperLoader.test.ts
+++ b/src/components/app/routes/tests/checkoutStepperLoader.test.ts
@@ -149,7 +149,7 @@ describe('makeCheckoutStepperLoader (stepper loaders)', () => {
       makeLoaderArgs(CheckoutStepKey.PlanDetails, CheckoutSubstepKey.Login, CheckoutPageRoute.PlanDetailsLogin),
     );
     expect(r2).not.toBeNull();
-    expect((r2 as any).headers.get('Location')).toBe(CheckoutPageRoute.PlanDetails);
+    expect((r2 as any).headers.get('Location')).toBe(CheckoutPageRoute.AccountDetails);
   });
   it('PlanDetailsRegister redirects when authenticated, null otherwise', async () => {
     const loader = makeCheckoutStepperLoader(queryClient);
@@ -164,7 +164,7 @@ describe('makeCheckoutStepperLoader (stepper loaders)', () => {
       makeLoaderArgs(CheckoutStepKey.PlanDetails, CheckoutSubstepKey.Register, CheckoutPageRoute.PlanDetailsRegister),
     );
     expect(r2).not.toBeNull();
-    expect((r2 as any).headers.get('Location')).toBe(CheckoutPageRoute.PlanDetails);
+    expect((r2 as any).headers.get('Location')).toBe(CheckoutPageRoute.AccountDetails);
   });
   it.each(generateTestPermutations({
     authenticatedUser: [{ userId: 1 }, null],
@@ -187,7 +187,7 @@ describe('makeCheckoutStepperLoader (stepper loaders)', () => {
       makeLoaderArgs(CheckoutStepKey.PlanDetails, loaderArguments.subStep, loaderArguments.route),
     );
     expect(r1).not.toBeNull();
-    expect((r1 as any).headers.get('Location')).toBe(CheckoutPageRoute.PlanDetails);
+    expect((r1 as any).headers.get('Location')).toBe(CheckoutPageRoute.AccountDetails);
   });
   describe('AccountDetails loader', () => {
     it('redirects unauthenticated users to Plan Details', async () => {
@@ -378,7 +378,7 @@ describe('Essentials flow redirects', () => {
 
     expect(result).not.toBeNull();
     expect((result as any).headers.get('Location')).toBe(
-      EssentialsPageRoute.PlanDetails,
+      EssentialsPageRoute.AccountDetails,
     );
   });
 
@@ -396,7 +396,7 @@ describe('Essentials flow redirects', () => {
 
     expect(result).not.toBeNull();
     expect((result as any).headers.get('Location')).toBe(
-      EssentialsPageRoute.PlanDetails,
+      EssentialsPageRoute.AccountDetails,
     );
   });
 });

--- a/src/components/app/routes/tests/rootLoader.test.ts
+++ b/src/components/app/routes/tests/rootLoader.test.ts
@@ -379,6 +379,104 @@ describe('makeRootLoader (rootLoader) tests', () => {
       .toBe('SSP_SITE_CHECKOUT');
     expect(result).toBeNull();
   });
+  it('redirects authenticated user from Checkout PlanDetails to AccountDetails when postRegister is true', async () => {
+    const authenticatedUser = {
+      email: 'a@b.com',
+      name: 'Alice',
+      username: 'alice',
+      country: 'US',
+    };
+  
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(authenticatedUser);
+  
+    // Simulate post-registration flag
+    sessionStorage.setItem('postRegister', 'true');
+  
+    const loader = makeRootLoader(queryClient);
+  
+    const result = await loader({
+      request: makeRequest(CheckoutPageRoute.PlanDetails),
+    } as any);
+  
+    // Redirect happens
+    expect(result).not.toBeNull();
+    const res = result as any;
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe(
+      CheckoutPageRoute.AccountDetails,
+    );
+  
+    // postRegister is cleared
+    expect(sessionStorage.getItem('postRegister')).toBeNull();
+  });
+  it('redirects authenticated user from Essentials PlanDetails to Essentials AccountDetails when postRegister is true', async () => {
+    const authenticatedUser = {
+      email: 'a@b.com',
+      name: 'Alice',
+      username: 'alice',
+      country: 'US',
+    };
+  
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(authenticatedUser);
+  
+    // ✅ ENABLE essentials feature for this test
+    (getConfig as jest.Mock).mockReturnValue({
+      FEATURE_SELF_SERVICE_PURCHASING: true,
+      FEATURE_SELF_SERVICE_PURCHASING_KEY: null,
+      FEATURE_SELF_SERVICE_ESSENTIALS: true,
+      FEATURE_SELF_SERVICE_ESSENTIALS_KEY: null,
+      FEATURE_SELF_SERVICE_SITE_KEY: null,
+    });
+  
+    sessionStorage.setItem('postRegister', 'true');
+  
+    const loader = makeRootLoader(queryClient);
+  
+    const result = await loader({
+      request: makeRequest(EssentialsPageRoute.PlanDetails),
+    } as any);
+  
+    expect(result).not.toBeNull();
+    const res = result as any;
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe(
+      EssentialsPageRoute.AccountDetails,
+    );
+  
+    expect(sessionStorage.getItem('postRegister')).toBeNull();
+  });
+  it('does not redirect when postRegister is true but path is not PlanDetails', async () => {
+    const authenticatedUser = {
+      email: 'a@b.com',
+      name: 'Alice',
+      username: 'alice',
+      country: 'US',
+    };
+  
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(authenticatedUser);
+  
+    (utilsMod.determineExistingCheckoutIntentState as jest.Mock).mockReturnValue({
+      existingSuccessfulCheckoutIntent: false,
+      expiredCheckoutIntent: false,
+    });
+  
+    ensureSpy.mockResolvedValue({
+      checkoutIntent: { state: 'requires_payment' },
+    } as any);
+  
+    sessionStorage.setItem('postRegister', 'true');
+  
+    const loader = makeRootLoader(queryClient);
+  
+    const result = await loader({
+      request: makeRequest(CheckoutPageRoute.BillingDetails),
+    } as any);
+  
+    expect(result).toBeNull();
+  
+    expect(sessionStorage.getItem('postRegister')).toBe('true');
+  });
+  
 });
 
 describe('AppShell route shouldRevalidate', () => {

--- a/src/components/app/routes/tests/rootLoader.test.ts
+++ b/src/components/app/routes/tests/rootLoader.test.ts
@@ -386,18 +386,18 @@ describe('makeRootLoader (rootLoader) tests', () => {
       username: 'alice',
       country: 'US',
     };
-  
+
     (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(authenticatedUser);
-  
+
     // Simulate post-registration flag
     sessionStorage.setItem('postRegister', 'true');
-  
+
     const loader = makeRootLoader(queryClient);
-  
+
     const result = await loader({
       request: makeRequest(CheckoutPageRoute.PlanDetails),
     } as any);
-  
+
     // Redirect happens
     expect(result).not.toBeNull();
     const res = result as any;
@@ -405,7 +405,7 @@ describe('makeRootLoader (rootLoader) tests', () => {
     expect(res.headers.get('Location')).toBe(
       CheckoutPageRoute.AccountDetails,
     );
-  
+
     // postRegister is cleared
     expect(sessionStorage.getItem('postRegister')).toBeNull();
   });
@@ -416,9 +416,9 @@ describe('makeRootLoader (rootLoader) tests', () => {
       username: 'alice',
       country: 'US',
     };
-  
+
     (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(authenticatedUser);
-  
+
     // ✅ ENABLE essentials feature for this test
     (getConfig as jest.Mock).mockReturnValue({
       FEATURE_SELF_SERVICE_PURCHASING: true,
@@ -427,22 +427,22 @@ describe('makeRootLoader (rootLoader) tests', () => {
       FEATURE_SELF_SERVICE_ESSENTIALS_KEY: null,
       FEATURE_SELF_SERVICE_SITE_KEY: null,
     });
-  
+
     sessionStorage.setItem('postRegister', 'true');
-  
+
     const loader = makeRootLoader(queryClient);
-  
+
     const result = await loader({
       request: makeRequest(EssentialsPageRoute.PlanDetails),
     } as any);
-  
+
     expect(result).not.toBeNull();
     const res = result as any;
     expect(res.status).toBe(302);
     expect(res.headers.get('Location')).toBe(
       EssentialsPageRoute.AccountDetails,
     );
-  
+
     expect(sessionStorage.getItem('postRegister')).toBeNull();
   });
   it('does not redirect when postRegister is true but path is not PlanDetails', async () => {
@@ -452,31 +452,30 @@ describe('makeRootLoader (rootLoader) tests', () => {
       username: 'alice',
       country: 'US',
     };
-  
+
     (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(authenticatedUser);
-  
+
     (utilsMod.determineExistingCheckoutIntentState as jest.Mock).mockReturnValue({
       existingSuccessfulCheckoutIntent: false,
       expiredCheckoutIntent: false,
     });
-  
+
     ensureSpy.mockResolvedValue({
       checkoutIntent: { state: 'requires_payment' },
     } as any);
-  
+
     sessionStorage.setItem('postRegister', 'true');
-  
+
     const loader = makeRootLoader(queryClient);
-  
+
     const result = await loader({
       request: makeRequest(CheckoutPageRoute.BillingDetails),
     } as any);
-  
+
     expect(result).toBeNull();
-  
+
     expect(sessionStorage.getItem('postRegister')).toBe('true');
   });
-  
 });
 
 describe('AppShell route shouldRevalidate', () => {

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -39,7 +39,7 @@ import {
   useCurrentPageDetails,
 } from '@/hooks/index';
 import useCurrentStep from '@/hooks/useCurrentStep';
-import { sendEnterpriseCheckoutPageEvent, sendEnterpriseCheckoutTrackingEvent } from '@/utils/common';
+import { sendEnterpriseCheckoutPageEvent } from '@/utils/common';
 
 import PlanDetailsSubmitButton from './PlanDetailsSubmitButton';
 

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -163,7 +163,6 @@ const PlanDetailsPage = () => {
         quantity: planDetailsFormData.quantity,
         country: planDetailsFormData.country,
       });
-      navigate(buildCheckoutPath(CheckoutPageRoute.AccountDetails));
     },
     onError: (errorMessage) => {
       setIsSubmitting(false);
@@ -176,7 +175,6 @@ const PlanDetailsPage = () => {
 
   const registerMutation = useRegisterMutation({
     onSuccess: () => {
-      setIsSubmitting(false);
       sessionStorage.setItem('postRegister', 'true');
       createCheckoutIntentMutation.mutate({
         quantity: planDetailsFormData.quantity,

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -117,62 +117,6 @@ const PlanDetailsPage = () => {
     setError,
   } = form;
 
-  const loginMutation = useLoginMutation({
-    onSuccess: () => {
-      setIsSubmitting(false);
-      navigate(buildCheckoutPath(CheckoutPageRoute.PlanDetails));
-    },
-    onError: (errorMessage) => {
-      setIsSubmitting(false);
-      setError('password', {
-        type: 'manual',
-        message: errorMessage,
-      });
-    },
-  });
-
-  const registerMutation = useRegisterMutation({
-    onSuccess: () => {
-      setIsSubmitting(false);
-
-      // Fire registration success tracking event
-      try {
-        sendEnterpriseCheckoutTrackingEvent({
-          checkoutIntentId,
-          eventName: EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CHECKOUT_REGISTRATION_SUCCESS,
-          properties: {
-            step: currentStepKey,
-            substep: currentSubstepKey,
-            plan_type: PLAN_TYPE.TEAMS,
-          },
-        });
-      } catch (error) {
-        logError('Failed to send registration success tracking event', error);
-      }
-
-      navigate(buildCheckoutPath(CheckoutPageRoute.PlanDetails));
-    },
-    onError: (errorMessage, errorData) => {
-      // Check if the response contains field-level validation errors for email
-      const emailErrorMessage = errorData?.errorCode === 'validation-error'
-        ? errorData?.email?.[0]?.userMessage
-        : null;
-
-      if (emailErrorMessage) {
-        setError('adminEmail', {
-          type: 'manual',
-          message: emailErrorMessage,
-        });
-      }
-
-      setIsSubmitting(false);
-      setError('root.serverError', {
-        type: 'manual',
-        message: errorMessage || 'Registration failed',
-      });
-    },
-  });
-
   // Use existing checkout intent if already created (avoid duplicate POST)
   async function queryClientInvalidate(userId?: number) {
     if (!userId) {
@@ -209,6 +153,54 @@ const PlanDetailsPage = () => {
           message: 'Server Error',
         });
       }
+    },
+  });
+
+  const loginMutation = useLoginMutation({
+    onSuccess: () => {
+      // setIsSubmitting(false);
+      createCheckoutIntentMutation.mutate({
+        quantity: planDetailsFormData.quantity,
+        country: planDetailsFormData.country,
+      });
+      navigate(buildCheckoutPath(CheckoutPageRoute.AccountDetails));
+    },
+    onError: (errorMessage) => {
+      setIsSubmitting(false);
+      setError('password', {
+        type: 'manual',
+        message: errorMessage,
+      });
+    },
+  });
+
+  const registerMutation = useRegisterMutation({
+    onSuccess: () => {
+      setIsSubmitting(false);
+      sessionStorage.setItem('postRegister', 'true');
+      createCheckoutIntentMutation.mutate({
+        quantity: planDetailsFormData.quantity,
+        country: planDetailsFormData.country,
+      });
+    },
+    onError: (errorMessage, errorData) => {
+      // Check if the response contains field-level validation errors for email
+      const emailErrorMessage = errorData?.errorCode === 'validation-error'
+        ? errorData?.email?.[0]?.userMessage
+        : null;
+
+      if (emailErrorMessage) {
+        setError('adminEmail', {
+          type: 'manual',
+          message: emailErrorMessage,
+        });
+      }
+
+      setIsSubmitting(false);
+      setError('root.serverError', {
+        type: 'manual',
+        message: errorMessage || 'Registration failed',
+      });
     },
   });
 

--- a/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
+++ b/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
@@ -1068,7 +1068,7 @@ describe('PlanDetailsPage – Essentials navigation', () => {
 
     // Assert the essentials-prefixed navigation happened
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/essentials/plan-details');
+      expect(mockNavigate).toHaveBeenCalledWith('/essentials/account-details');
     });
   });
 
@@ -1096,7 +1096,7 @@ describe('PlanDetailsPage – Essentials navigation', () => {
     await user.click(screen.getByTestId('stepper-submit-button'));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/essentials/plan-details');
+      expect(mockNavigate).toHaveBeenCalledWith('/essentials/account-details');
     });
   });
 });


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-11712


When a user starts Essentials checkout from a Plan Details page and is not logged in and a new user, they are taken to the Register page.

After the user completes registration (all required fields valid and submitted successfully), the system must:

Create the user and log them in, and

Navigate them directly to the Account Details (Step 2) page of the Essentials checkout flow,

instead of sending them back to the Plan Details page.

This ensures a smooth flow: Plan Details → Register → Account Details (logged-in state) for new, authenticated users.

 