### PR TITLE
fix: normalizes empty string field on account details

### DIFF
--- a/src/constants/checkout.ts
+++ b/src/constants/checkout.ts
@@ -213,58 +213,81 @@ export const PlanDetailsSchema = (
   stripePriceId: z.string().trim().optional().nullable(),
 }));
 
+const stringRequired = (min: number, max: number, requiredMsg: string, maxMsg: string) =>
+  z.preprocess(
+    (val) => val ?? '',
+    z.string()
+      .trim()
+      .min(min, requiredMsg)
+      .max(max, maxMsg)
+  );
+
 export const AccountDetailsSchema = (
   constraints: CheckoutContextFieldConstraints,
   adminEmail?: string,
-) => (z.object({
-  companyName: z.string().trim()
-    .min(
+) =>
+  z.object({
+    companyName: stringRequired(
       constraints?.companyName?.minLength ?? 1,
-      'Company name is required',
-    )
-    .max(
       constraints?.companyName?.maxLength ?? 255,
+      'Company name is required',
       `Maximum ${constraints?.companyName?.maxLength ?? 255} characters`,
-    )
-    .superRefine(async (companyName, ctx) => {
+    ).superRefine(async (companyName, ctx) => {
+      if (!companyName) { return; }
+
       const { isValid, validationDecisions } = await validateFieldDetailed(
         'companyName',
         companyName,
       );
+
       if (!isValid && validationDecisions?.companyName) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: serverValidationError('companyName', validationDecisions, CheckoutErrorMessagesByField),
+          message: serverValidationError(
+            'companyName',
+            validationDecisions,
+            CheckoutErrorMessagesByField,
+          ),
         });
       }
     }),
-  enterpriseSlug: z.string().trim()
-    .min(
-      constraints?.enterpriseSlug?.minLength ?? 1,
-      'Company Url is required',
-    )
-    .max(
-      constraints?.enterpriseSlug?.maxLength ?? 255,
-      `Maximum ${constraints?.enterpriseSlug?.maxLength ?? 255} characters`,
-    )
-    .regex(
-      new RegExp(constraints?.enterpriseSlug?.pattern ?? '^[a-z0-9-]+$'),
-      'Only alphanumeric lowercase characters and hyphens are allowed.',
-    )
-    .superRefine(async (enterpriseSlug, ctx) => {
+    enterpriseSlug: z.preprocess(
+      (val) => val ?? '',
+      z.string()
+        .trim()
+        .min(
+          constraints?.enterpriseSlug?.minLength ?? 1,
+          'Company Url is required',
+        )
+        .max(
+          constraints?.enterpriseSlug?.maxLength ?? 255,
+          `Maximum ${constraints?.enterpriseSlug?.maxLength ?? 255} characters`,
+        )
+        .regex(
+          new RegExp(constraints?.enterpriseSlug?.pattern ?? '^[a-z0-9-]+$'),
+          'Only alphanumeric lowercase characters and hyphens are allowed.',
+        ),
+    ).superRefine(async (enterpriseSlug, ctx) => {
+      if (!enterpriseSlug) { return; }
+
       const { isValid, validationDecisions } = await validateFieldDetailed(
         'enterpriseSlug',
         enterpriseSlug,
         { adminEmail: adminEmail || '' },
       );
+
       if (!isValid && validationDecisions?.enterpriseSlug) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: serverValidationError('enterpriseSlug', validationDecisions, CheckoutErrorMessagesByField),
+          message: serverValidationError(
+            'enterpriseSlug',
+            validationDecisions,
+            CheckoutErrorMessagesByField,
+          ),
         });
       }
     }),
-}));
+  });
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/constants/checkout.ts
+++ b/src/constants/checkout.ts
@@ -213,81 +213,79 @@ export const PlanDetailsSchema = (
   stripePriceId: z.string().trim().optional().nullable(),
 }));
 
-const stringRequired = (min: number, max: number, requiredMsg: string, maxMsg: string) =>
-  z.preprocess(
-    (val) => val ?? '',
-    z.string()
-      .trim()
-      .min(min, requiredMsg)
-      .max(max, maxMsg)
-  );
+const stringRequired = (min: number, max: number, requiredMsg: string, maxMsg: string) => z.preprocess(
+  (val) => val ?? '',
+  z.string()
+    .trim()
+    .min(min, requiredMsg)
+    .max(max, maxMsg),
+);
 
 export const AccountDetailsSchema = (
   constraints: CheckoutContextFieldConstraints,
   adminEmail?: string,
-) =>
-  z.object({
-    companyName: stringRequired(
-      constraints?.companyName?.minLength ?? 1,
-      constraints?.companyName?.maxLength ?? 255,
-      'Company name is required',
-      `Maximum ${constraints?.companyName?.maxLength ?? 255} characters`,
-    ).superRefine(async (companyName, ctx) => {
-      if (!companyName) { return; }
+) => z.object({
+  companyName: stringRequired(
+    constraints?.companyName?.minLength ?? 1,
+    constraints?.companyName?.maxLength ?? 255,
+    'Company name is required',
+    `Maximum ${constraints?.companyName?.maxLength ?? 255} characters`,
+  ).superRefine(async (companyName, ctx) => {
+    if (!companyName) { return; }
 
-      const { isValid, validationDecisions } = await validateFieldDetailed(
-        'companyName',
-        companyName,
-      );
+    const { isValid, validationDecisions } = await validateFieldDetailed(
+      'companyName',
+      companyName,
+    );
 
-      if (!isValid && validationDecisions?.companyName) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: serverValidationError(
-            'companyName',
-            validationDecisions,
-            CheckoutErrorMessagesByField,
-          ),
-        });
-      }
-    }),
-    enterpriseSlug: z.preprocess(
-      (val) => val ?? '',
-      z.string()
-        .trim()
-        .min(
-          constraints?.enterpriseSlug?.minLength ?? 1,
-          'Company Url is required',
-        )
-        .max(
-          constraints?.enterpriseSlug?.maxLength ?? 255,
-          `Maximum ${constraints?.enterpriseSlug?.maxLength ?? 255} characters`,
-        )
-        .regex(
-          new RegExp(constraints?.enterpriseSlug?.pattern ?? '^[a-z0-9-]+$'),
-          'Only alphanumeric lowercase characters and hyphens are allowed.',
+    if (!isValid && validationDecisions?.companyName) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: serverValidationError(
+          'companyName',
+          validationDecisions,
+          CheckoutErrorMessagesByField,
         ),
-    ).superRefine(async (enterpriseSlug, ctx) => {
-      if (!enterpriseSlug) { return; }
+      });
+    }
+  }),
+  enterpriseSlug: z.preprocess(
+    (val) => val ?? '',
+    z.string()
+      .trim()
+      .min(
+        constraints?.enterpriseSlug?.minLength ?? 1,
+        'Company Url is required',
+      )
+      .max(
+        constraints?.enterpriseSlug?.maxLength ?? 255,
+        `Maximum ${constraints?.enterpriseSlug?.maxLength ?? 255} characters`,
+      )
+      .regex(
+        new RegExp(constraints?.enterpriseSlug?.pattern ?? '^[a-z0-9-]+$'),
+        'Only alphanumeric lowercase characters and hyphens are allowed.',
+      ),
+  ).superRefine(async (enterpriseSlug, ctx) => {
+    if (!enterpriseSlug) { return; }
 
-      const { isValid, validationDecisions } = await validateFieldDetailed(
-        'enterpriseSlug',
-        enterpriseSlug,
-        { adminEmail: adminEmail || '' },
-      );
+    const { isValid, validationDecisions } = await validateFieldDetailed(
+      'enterpriseSlug',
+      enterpriseSlug,
+      { adminEmail: adminEmail || '' },
+    );
 
-      if (!isValid && validationDecisions?.enterpriseSlug) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: serverValidationError(
-            'enterpriseSlug',
-            validationDecisions,
-            CheckoutErrorMessagesByField,
-          ),
-        });
-      }
-    }),
-  });
+    if (!isValid && validationDecisions?.enterpriseSlug) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: serverValidationError(
+          'enterpriseSlug',
+          validationDecisions,
+          CheckoutErrorMessagesByField,
+        ),
+      });
+    }
+  }),
+});
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/constants/tests/AccountDetailsSchema.test.ts
+++ b/src/constants/tests/AccountDetailsSchema.test.ts
@@ -1,0 +1,63 @@
+import { validateFieldDetailed } from '@/components/app/data/services/validation';
+
+import { AccountDetailsSchema } from '../checkout';
+
+jest.mock('@/components/app/data/services/validation', () => ({
+  validateFieldDetailed: jest.fn(),
+}));
+
+jest.mock('@/utils/common', () => ({
+  serverValidationError: jest.fn(),
+}));
+
+describe('AccountDetailsSchema', () => {
+  const constraints = {
+    companyName: { minLength: 1, maxLength: 255 },
+    enterpriseSlug: { minLength: 1, maxLength: 255, pattern: '^[a-z0-9-]+$' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (validateFieldDetailed as jest.Mock).mockResolvedValue({ isValid: true });
+  });
+
+  it('validates that companyName and enterpriseSlug are required when they are undefined', async () => {
+    const schema = AccountDetailsSchema(constraints);
+    const result = await schema.safeParseAsync({
+      companyName: undefined,
+      enterpriseSlug: undefined,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const { fieldErrors } = result.error.flatten();
+      expect(fieldErrors.companyName).toContain('Company name is required');
+      expect(fieldErrors.enterpriseSlug).toContain('Company Url is required');
+    }
+  });
+
+  it('validates that companyName and enterpriseSlug are required when they are null', async () => {
+    const schema = AccountDetailsSchema(constraints);
+    const result = await schema.safeParseAsync({
+      companyName: null,
+      enterpriseSlug: null,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const { fieldErrors } = result.error.flatten();
+      expect(fieldErrors.companyName).toContain('Company name is required');
+      expect(fieldErrors.enterpriseSlug).toContain('Company Url is required');
+    }
+  });
+
+  it('validates that companyName and enterpriseSlug pass validation when they are valid', async () => {
+    const schema = AccountDetailsSchema(constraints);
+    const result = await schema.safeParseAsync({
+      companyName: 'Acme Corp',
+      enterpriseSlug: 'acme-corp',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR is a followup fix after noticing inconsistent behavior between plan-details and acocunt details form validation.
On account details, if the user navigates to the page on the first instance, the zod validation does not execute correctly. The validation messaging defaults to the HTML default validation message of an undefined or null value.

This approach normalizes the value to an empty string BEFORE validation occurs to ensure zod resolvers can validate on page load. This is to support changes related to displaying validation errors on page traversal.


Github copilots description:
This pull request refactors the validation schema for account details in the checkout process to improve code clarity and reusability. The main changes include introducing a helper function for required string validation, streamlining the validation logic, and ensuring consistent preprocessing of input values.

**Validation schema improvements:**

* Introduced a `stringRequired` helper function to centralize and simplify the required string validation logic for fields like `companyName`.
* Updated the `companyName` and `enterpriseSlug` fields in `AccountDetailsSchema` to use the new helper and to consistently preprocess input values, ensuring empty values are handled as empty strings. [[1]](diffhunk://#diff-d0625680b4acd4119d5b0d983f93478e087bc11a7ecda87a792f2ac53c889999R216-R257) [[2]](diffhunk://#diff-d0625680b4acd4119d5b0d983f93478e087bc11a7ecda87a792f2ac53c889999L253-R290)
* Improved the `superRefine` logic for both fields to skip server-side validation if the value is empty, preventing unnecessary validation calls. [[1]](diffhunk://#diff-d0625680b4acd4119d5b0d983f93478e087bc11a7ecda87a792f2ac53c889999R216-R257) [[2]](diffhunk://#diff-d0625680b4acd4119d5b0d983f93478e087bc11a7ecda87a792f2ac53c889999L253-R290)
* Enhanced error messaging by formatting server validation errors for better readability. [[1]](diffhunk://#diff-d0625680b4acd4119d5b0d983f93478e087bc11a7ecda87a792f2ac53c889999R216-R257) [[2]](diffhunk://#diff-d0625680b4acd4119d5b0d983f93478e087bc11a7ecda87a792f2ac53c889999L253-R290)