### PR TITLE
feat: ENT-11756/SSP-Register-Account

### DIFF
--- a/src/components/app/routes/loaders/checkoutStepperLoader.ts
+++ b/src/components/app/routes/loaders/checkoutStepperLoader.ts
@@ -109,6 +109,9 @@ async function billingDetailsLoader(queryClient: QueryClient): Promise<Response 
   const authenticatedUser = getAuthenticatedUser();
   if (!authenticatedUser) {
     // If the user is NOT authenticated, redirect to PlanDetails Page.
+    if (isEssentialsFlow()) {
+      return redirect(EssentialsPageRoute.PlanDetails);
+    }
     return redirect(CheckoutPageRoute.PlanDetails);
   }
   const contextMetadata: CheckoutContextResponse = await queryClient.ensureQueryData(

--- a/src/components/app/routes/loaders/checkoutStepperLoader.ts
+++ b/src/components/app/routes/loaders/checkoutStepperLoader.ts
@@ -43,12 +43,10 @@ async function planDetailsLoginLoader(): Promise<Response | null> {
  */
 async function planDetailsRegisterLoader(): Promise<Response | null> {
   const authenticatedUser = getAuthenticatedUser();
-
   const planDetailsMetadata = checkoutFormStore.getState().formData[DataStoreKey.PlanDetails];
   const redirectToPlanDetails = !(
     planDetailsMetadata.adminEmail && planDetailsMetadata.fullName && planDetailsMetadata.country
   );
-
   if (redirectToPlanDetails || authenticatedUser) {
     // Redirect to PlanDetails if: (1) required metadata is missing, or (2) user is already authenticated.
     if (isEssentialsFlow()) {
@@ -70,6 +68,9 @@ async function accountDetailsLoader(queryClient: QueryClient): Promise<Response 
   const authenticatedUser = getAuthenticatedUser();
   if (!authenticatedUser) {
     // If the user is NOT authenticated, redirect to PlanDetails Page.
+    if (isEssentialsFlow()) {
+      return redirect(EssentialsPageRoute.PlanDetails);
+    }
     return redirect(CheckoutPageRoute.PlanDetails);
   }
 
@@ -110,7 +111,6 @@ async function billingDetailsLoader(queryClient: QueryClient): Promise<Response 
     // If the user is NOT authenticated, redirect to PlanDetails Page.
     return redirect(CheckoutPageRoute.PlanDetails);
   }
-
   const contextMetadata: CheckoutContextResponse = await queryClient.ensureQueryData(
     queryBffContext(authenticatedUser?.userId || null),
   );
@@ -138,6 +138,9 @@ async function billingDetailsLoader(queryClient: QueryClient): Promise<Response 
   const contextSecret = contextMetadata.checkoutIntent?.checkoutSessionClientSecret;
   const checkoutSessionClientSecret = formStoreSecret || contextSecret;
   if (!checkoutSessionClientSecret) {
+    if (isEssentialsFlow()) {
+      return redirect(EssentialsPageRoute.PlanDetails);
+    }
     return redirect(CheckoutPageRoute.PlanDetails);
   }
 

--- a/src/components/app/routes/tests/checkoutStepperLoader.test.ts
+++ b/src/components/app/routes/tests/checkoutStepperLoader.test.ts
@@ -399,4 +399,144 @@ describe('Essentials flow redirects', () => {
       EssentialsPageRoute.PlanDetails,
     );
   });
+
+  it('AccountDetails loader redirects unauthenticated users to Essentials PlanDetails', async () => {
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(null);
+    const loader = makeCheckoutStepperLoader(queryClient);
+    const result = await loader(
+      makeLoaderArgs(CheckoutStepKey.AccountDetails, undefined, EssentialsPageRoute.AccountDetails),
+    );
+    expect(result).not.toBeNull();
+    expect((result as any).headers.get('Location')).toBe(EssentialsPageRoute.PlanDetails);
+  });
+
+  it('BillingDetails loader redirects unauthenticated users to Essentials PlanDetails', async () => {
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue(null);
+    const loader = makeCheckoutStepperLoader(queryClient);
+    const result = await loader(
+      makeLoaderArgs(CheckoutStepKey.BillingDetails, undefined, EssentialsPageRoute.BillingDetails),
+    );
+    expect(result).not.toBeNull();
+    expect((result as any).headers.get('Location')).toBe(EssentialsPageRoute.PlanDetails);
+  });
+
+  it('BillingDetails loader redirects to Plan Details when no Stripe price id found (loader does not check essentials for no-price path)', async () => {
+    const essentialsQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue({ userId: 1 });
+    jest.spyOn(essentialsQueryClient, 'ensureQueryData').mockResolvedValue(
+      buildContext({ withPrice: false }),
+    );
+    const loader = makeCheckoutStepperLoader(essentialsQueryClient);
+    const result = await loader(
+      makeLoaderArgs(CheckoutStepKey.BillingDetails, undefined, EssentialsPageRoute.BillingDetails),
+    );
+    expect(result).not.toBeNull();
+    // billingDetailsLoader does not guard the no-price branch with isEssentialsFlow
+    expect((result as any).headers.get('Location')).toBe(CheckoutPageRoute.PlanDetails);
+  });
+
+  it('BillingDetails loader redirects to Essentials PlanDetails when checkout session is missing', async () => {
+    const essentialsQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue({ userId: 1 });
+    const ctx = buildContext({ withPrice: true });
+    jest.spyOn(essentialsQueryClient, 'ensureQueryData').mockResolvedValue(ctx);
+    const { pricing } = ctx;
+    populateValidPlanDetails(pricing.prices[0].id as string);
+    populateValidAccountDetails();
+    const loader = makeCheckoutStepperLoader(essentialsQueryClient);
+    const result = await loader(
+      makeLoaderArgs(CheckoutStepKey.BillingDetails, undefined, EssentialsPageRoute.BillingDetails),
+    );
+    expect(result).not.toBeNull();
+    expect((result as any).headers.get('Location')).toBe(EssentialsPageRoute.PlanDetails);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// billingDetailsLoader – formStoreSecret fallback
+// ---------------------------------------------------------------------------
+
+describe('billingDetailsLoader – formStoreSecret fallback', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetFormStore();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  it('returns null when checkout session secret comes from the Zustand form store (not context)', async () => {
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue({ userId: 1 });
+    // Context has NO inline secret
+    const ctx = buildContext({ withPrice: true, includeCheckoutIntent: false });
+    jest.spyOn(queryClient, 'ensureQueryData').mockResolvedValue(ctx);
+    const { pricing } = ctx;
+    const stripePriceId = pricing.prices[0].id as string;
+    populateValidPlanDetails(stripePriceId);
+    populateValidAccountDetails();
+    // Inject secret only via the form store
+    checkoutFormStore.setState(s => ({
+      ...s,
+      checkoutSessionClientSecret: 'cs_test_from_store',
+    }), false);
+    const loader = makeCheckoutStepperLoader(queryClient);
+    const result = await loader(
+      makeLoaderArgs(CheckoutStepKey.BillingDetails, undefined, CheckoutPageRoute.BillingDetails),
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// billingDetailsSuccessLoader – success (null) paths
+// ---------------------------------------------------------------------------
+
+describe('billingDetailsSuccessLoader – null return paths', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetFormStore();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  it('returns null when checkoutSessionStatus type is "complete"', async () => {
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue({ userId: 1 });
+    const ctx = buildContext({ withPrice: true, includeCheckoutIntent: false });
+    jest.spyOn(queryClient, 'ensureQueryData').mockResolvedValue(ctx);
+    checkoutFormStore.setState(s => ({
+      ...s,
+      checkoutSessionStatus: { type: 'complete', paymentStatus: 'paid' },
+    }), false);
+    const loader = makeCheckoutStepperLoader(queryClient);
+    const result = await loader(
+      makeLoaderArgs(
+        CheckoutStepKey.BillingDetails,
+        CheckoutSubstepKey.Success,
+        CheckoutPageRoute.BillingDetailsSuccess,
+      ),
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when context has existingSuccessfulCheckoutIntent', async () => {
+    (authMod.getAuthenticatedUser as jest.Mock).mockReturnValue({ userId: 1 });
+    const ctx = {
+      ...buildContext({ withPrice: true, includeCheckoutIntent: true }),
+      checkoutIntent: {
+        ...buildContext({ withPrice: true, includeCheckoutIntent: true }).checkoutIntent,
+        existingSuccessfulCheckoutIntent: true,
+      },
+    };
+    jest.spyOn(queryClient, 'ensureQueryData').mockResolvedValue(ctx);
+    const loader = makeCheckoutStepperLoader(queryClient);
+    const result = await loader(
+      makeLoaderArgs(
+        CheckoutStepKey.BillingDetails,
+        CheckoutSubstepKey.Success,
+        CheckoutPageRoute.BillingDetailsSuccess,
+      ),
+    );
+    expect(result).toBeNull();
+  });
 });

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -48,7 +48,7 @@ import { sendEnterpriseCheckoutPageEvent } from '@/utils/common';
 
 import PlanDetailsSubmitButton from './PlanDetailsSubmitButton';
 
-// import '../Stepper/Steps/css/PriceAlert.css'
+import '../Stepper/Steps/css/PriceAlert.css'
 
 const PlanDetailsPage = () => {
   const location = useLocation();

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -1,3 +1,8 @@
+import {
+  fetchAuthenticatedUser,
+  getAuthenticatedUser,
+  hydrateAuthenticatedUser,
+} from '@edx/frontend-platform/auth';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { logError } from '@edx/frontend-platform/logging';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -39,11 +44,11 @@ import {
   useCurrentPageDetails,
 } from '@/hooks/index';
 import useCurrentStep from '@/hooks/useCurrentStep';
-import { sendEnterpriseCheckoutPageEvent, sendEnterpriseCheckoutTrackingEvent } from '@/utils/common';
+import { sendEnterpriseCheckoutPageEvent } from '@/utils/common';
 
 import PlanDetailsSubmitButton from './PlanDetailsSubmitButton';
 
-import '../Stepper/Steps/css/PriceAlert.css';
+// import '../Stepper/Steps/css/PriceAlert.css'
 
 const PlanDetailsPage = () => {
   const location = useLocation();
@@ -76,6 +81,21 @@ const PlanDetailsPage = () => {
 
   const lastTrackedPathRef = useRef<string | null>(null);
   const { currentStepKey, currentSubstepKey } = useCurrentStep();
+
+  async function invalidateCheckoutQueries(client) {
+    const userId = getAuthenticatedUser()?.userId;
+
+    // 1) Remove anonymous cached context so it can’t be reused by accident
+    client.removeQueries({ queryKey: queryBffContext(null).queryKey, exact: true });
+
+    // 2) Invalidate the logged-in user context so next ensureQueryData refetches
+    if (userId) {
+      await Promise.all([
+        client.invalidateQueries({ queryKey: queryBffContext(userId).queryKey }),
+        client.invalidateQueries({ queryKey: queryBffSuccess(userId).queryKey }),
+      ]);
+    }
+  }
 
   // Fire page view tracking event whenever the current page changes
   useEffect(() => {
@@ -119,63 +139,6 @@ const PlanDetailsPage = () => {
     setError,
   } = form;
 
-  const loginMutation = useLoginMutation({
-    onSuccess: () => {
-      setIsSubmitting(false);
-      navigate(buildCheckoutPath(CheckoutPageRoute.PlanDetails));
-    },
-    onError: (errorMessage) => {
-      setIsSubmitting(false);
-      setError('password', {
-        type: 'manual',
-        message: errorMessage,
-      });
-    },
-  });
-
-  const registerMutation = useRegisterMutation({
-    onSuccess: () => {
-      setIsSubmitting(false);
-
-      // Fire registration success tracking event
-      try {
-        sendEnterpriseCheckoutTrackingEvent({
-          checkoutIntentId,
-          checkoutIntentUuid,
-          eventName: EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CHECKOUT_REGISTRATION_SUCCESS,
-          properties: {
-            step: currentStepKey,
-            substep: currentSubstepKey,
-            plan_type: PLAN_TYPE.TEAMS,
-          },
-        });
-      } catch (error) {
-        logError('Failed to send registration success tracking event', error);
-      }
-
-      navigate(buildCheckoutPath(CheckoutPageRoute.PlanDetails));
-    },
-    onError: (errorMessage, errorData) => {
-      // Check if the response contains field-level validation errors for email
-      const emailErrorMessage = errorData?.errorCode === 'validation-error'
-        ? errorData?.email?.[0]?.userMessage
-        : null;
-
-      if (emailErrorMessage) {
-        setError('adminEmail', {
-          type: 'manual',
-          message: emailErrorMessage,
-        });
-      }
-
-      setIsSubmitting(false);
-      setError('root.serverError', {
-        type: 'manual',
-        message: errorMessage || 'Registration failed',
-      });
-    },
-  });
-
   // Use existing checkout intent if already created (avoid duplicate POST)
   async function queryClientInvalidate(userId?: number) {
     if (!userId) {
@@ -191,6 +154,7 @@ const PlanDetailsPage = () => {
     onSuccess: async () => {
       // Invalidate BFF context queries so downstream pages see the new intent.
       await queryClientInvalidate(authenticatedUser?.userId);
+
       setIsSubmitting(false);
       navigate(buildCheckoutPath(CheckoutPageRoute.AccountDetails));
     },
@@ -212,6 +176,69 @@ const PlanDetailsPage = () => {
           message: 'Server Error',
         });
       }
+    },
+  });
+
+  const loginMutation = useLoginMutation({
+    onSuccess: async () => {
+      setIsSubmitting(false);
+      await fetchAuthenticatedUser();
+      await hydrateAuthenticatedUser();
+      createCheckoutIntentMutation.mutate({
+        quantity: planDetailsFormData.quantity,
+        country: planDetailsFormData.country,
+      });
+      await invalidateCheckoutQueries(queryClient);
+      const userId = getAuthenticatedUser()?.userId;
+      if (userId) {
+        await queryClient.fetchQuery(queryBffContext(userId));
+      }
+    },
+    onError: (errorMessage) => {
+      setIsSubmitting(false);
+      setError('password', {
+        type: 'manual',
+        message: errorMessage,
+      });
+    },
+  });
+
+  const registerMutation = useRegisterMutation({
+    onSuccess: async () => {
+      setIsSubmitting(false);
+      await fetchAuthenticatedUser();
+      await hydrateAuthenticatedUser();
+
+      createCheckoutIntentMutation.mutate({
+        quantity: planDetailsFormData.quantity,
+        country: planDetailsFormData.country,
+      });
+      // Now refresh context cache used by rootLoader/loaders
+      await invalidateCheckoutQueries(queryClient);
+      // Optional hard guarantee: force a network read immediately
+      const userId = getAuthenticatedUser()?.userId;
+      if (userId) {
+        await queryClient.fetchQuery(queryBffContext(userId));
+      }
+    },
+    onError: (errorMessage, errorData) => {
+      // Check if the response contains field-level validation errors for email
+      const emailErrorMessage = errorData?.errorCode === 'validation-error'
+        ? errorData?.email?.[0]?.userMessage
+        : null;
+
+      if (emailErrorMessage) {
+        setError('adminEmail', {
+          type: 'manual',
+          message: emailErrorMessage,
+        });
+      }
+
+      setIsSubmitting(false);
+      setError('root.serverError', {
+        type: 'manual',
+        message: errorMessage || 'Registration failed',
+      });
     },
   });
 
@@ -293,7 +320,7 @@ const PlanDetailsPage = () => {
       case SubmitCallbacks.PlanDetailsRegister:
         return registerMutation;
       default:
-        // Safe fallback if currentPage is undefined or unexpected.
+        // Safe fallback if currentPage is undefined or unexpected.<<
         return { isPending: false, isSuccess: false, isError: false } as {
           isPending: boolean; isSuccess: boolean; isError: boolean;
         };

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -48,7 +48,7 @@ import { sendEnterpriseCheckoutPageEvent } from '@/utils/common';
 
 import PlanDetailsSubmitButton from './PlanDetailsSubmitButton';
 
-import '../Stepper/Steps/css/PriceAlert.css'
+import '../Stepper/Steps/css/PriceAlert.css';
 
 const PlanDetailsPage = () => {
   const location = useLocation();

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -44,7 +44,7 @@ import {
   useCurrentPageDetails,
 } from '@/hooks/index';
 import useCurrentStep from '@/hooks/useCurrentStep';
-import { sendEnterpriseCheckoutPageEvent } from '@/utils/common';
+import { sendEnterpriseCheckoutPageEvent, sendEnterpriseCheckoutTrackingEvent } from '@/utils/common';
 
 import PlanDetailsSubmitButton from './PlanDetailsSubmitButton';
 
@@ -219,6 +219,20 @@ const PlanDetailsPage = () => {
       const userId = getAuthenticatedUser()?.userId;
       if (userId) {
         await queryClient.fetchQuery(queryBffContext(userId));
+      }
+      try {
+        sendEnterpriseCheckoutTrackingEvent({
+          checkoutIntentId,
+          checkoutIntentUuid,
+          eventName: EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CHECKOUT_REGISTRATION_SUCCESS,
+          properties: {
+            step: currentStepKey,
+            substep: currentSubstepKey,
+            plan_type: PLAN_TYPE.TEAMS,
+          },
+        });
+      } catch (error) {
+        logError('Failed to send registration success tracking event', error);
       }
     },
     onError: (errorMessage, errorData) => {

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -320,7 +320,7 @@ const PlanDetailsPage = () => {
       case SubmitCallbacks.PlanDetailsRegister:
         return registerMutation;
       default:
-        // Safe fallback if currentPage is undefined or unexpected.<<
+        // Safe fallback if currentPage is undefined or unexpected.
         return { isPending: false, isSuccess: false, isError: false } as {
           isPending: boolean; isSuccess: boolean; isError: boolean;
         };

--- a/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
+++ b/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
@@ -1037,8 +1037,6 @@ describe('PlanDetailsPage – Essentials navigation', () => {
   });
 
   it('PlanDetailsLogin (essentials): successful login → navigates to /essentials/account-details', async () => {
-    // const user = userEvent.setup();
-
     // Provide safe constraints so form schema resolves
     (useFormValidationConstraints as jest.Mock).mockReturnValue({
       data: { quantity: { min: 5, max: 30 } },

--- a/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
+++ b/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
@@ -1392,3 +1392,192 @@ describe('PlanDetailsPage – registerMutation success/error paths', () => {
     expect(mockNavigate).not.toHaveBeenCalledWith(CheckoutPageRoute.AccountDetails);
   });
 });
+
+// ---------------------------------------------------------------------------
+// registerMutation.onSuccess – registration tracking event
+// ---------------------------------------------------------------------------
+
+describe('PlanDetailsPage – registerMutation tracking event', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue(undefined as any);
+    jest.spyOn(QueryClient.prototype, 'fetchQuery').mockResolvedValue(undefined as any);
+    jest.spyOn(QueryClient.prototype, 'removeQueries').mockImplementation(() => undefined);
+
+    (useFormValidationConstraints as jest.Mock).mockReturnValue({
+      data: { quantity: { min: 5, max: 30 } },
+    });
+
+    const { useRecaptchaToken } = jest.requireMock('@/components/app/data');
+    (useRecaptchaToken as jest.Mock).mockReturnValue(
+      { getToken: jest.fn().mockResolvedValue('test-token'), isLoading: false, isReady: true },
+    );
+
+    setupBFFContextMock();
+
+    checkoutFormStore.setState((state: any) => ({
+      ...state,
+      formData: {
+        ...state.formData,
+        [DataStoreKey.PlanDetails]: {
+          adminEmail: 'newuser@example.com',
+          fullName: 'New User',
+          country: 'US',
+          quantity: 10,
+        },
+      },
+    }));
+  });
+
+  it('sends CHECKOUT_REGISTRATION_SUCCESS tracking event after successful registration', async () => {
+    const { sendTrackEvent } = await import('@edx/frontend-platform/analytics');
+
+    const useRegisterMutationMock = (await import('@/components/app/data/hooks/useRegisterMutation')).default as jest.Mock;
+    const useCreateCheckoutIntentMutationMock = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation')).default as jest.Mock;
+
+    useRegisterMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    useCreateCheckoutIntentMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsRegister);
+
+    await userEvent.type(screen.getByLabelText(/public username/i), 'newuser');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    await waitFor(() => {
+      expect(sendTrackEvent).toHaveBeenCalledWith(
+        EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CHECKOUT_REGISTRATION_SUCCESS,
+        expect.objectContaining({
+          plan_type: PLAN_TYPE.TEAMS,
+        }),
+      );
+    });
+  });
+
+  it('catches and logs tracking event error without breaking navigation', async () => {
+    const { logError } = await import('@edx/frontend-platform/logging');
+    const { sendTrackEvent } = await import('@edx/frontend-platform/analytics');
+    // Only throw for the registration success event; let field-blur tracking pass through
+    (sendTrackEvent as jest.Mock).mockImplementation((eventName: string) => {
+      if (eventName === EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CHECKOUT_REGISTRATION_SUCCESS) {
+        throw new Error('tracking boom');
+      }
+    });
+
+    const useRegisterMutationMock = (await import('@/components/app/data/hooks/useRegisterMutation')).default as jest.Mock;
+    const useCreateCheckoutIntentMutationMock = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation')).default as jest.Mock;
+
+    useRegisterMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    useCreateCheckoutIntentMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsRegister);
+
+    await userEvent.type(screen.getByLabelText(/public username/i), 'newuser');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalledWith(
+        'Failed to send registration success tracking event',
+        expect.any(Error),
+      );
+    });
+
+    // Navigation still proceeds despite tracking failure
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(CheckoutPageRoute.AccountDetails);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCheckoutIntentMutation – onError paths
+// ---------------------------------------------------------------------------
+
+describe('PlanDetailsPage – createCheckoutIntentMutation error paths', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useFormValidationConstraints as jest.Mock).mockReturnValue({
+      data: { quantity: { min: 5, max: 30 } },
+    });
+
+    setupBFFContextMock();
+
+    checkoutFormStore.setState((state: any) => ({
+      ...state,
+      formData: {
+        ...state.formData,
+        [DataStoreKey.PlanDetails]: {
+          adminEmail: 'admin@example.com',
+          fullName: 'Admin User',
+          country: 'US',
+          quantity: 10,
+        },
+      },
+    }));
+  });
+
+  it('sets quantity field error when server returns quantity errorCode', async () => {
+    const useCreateCheckoutIntentMutationMock = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation')).default as jest.Mock;
+
+    useCreateCheckoutIntentMutationMock.mockImplementation(({ onError }: any) => ({
+      mutate: jest.fn(() => onError?.({ quantity: { errorCode: 'quantity_exceeds_limit' } })),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetails, { config: {}, authenticatedUser: { userId: 1 } });
+
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('quantity_exceeds_limit')).toBeInTheDocument();
+    });
+  });
+
+  it('sets root server error when checkout intent fails with a non-object error', async () => {
+    const useCreateCheckoutIntentMutationMock = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation')).default as jest.Mock;
+    const mutateSpy = jest.fn();
+
+    useCreateCheckoutIntentMutationMock.mockImplementation(({ onError }: any) => ({
+      mutate: mutateSpy.mockImplementation(() => onError?.(null)),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetails, { config: {}, authenticatedUser: { userId: 1 } });
+
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    // Navigation must not have occurred
+    expect(mockNavigate).not.toHaveBeenCalledWith(CheckoutPageRoute.AccountDetails);
+  });
+});

--- a/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
+++ b/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
@@ -1,4 +1,5 @@
 import { getConfig } from '@edx/frontend-platform/config';
+import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -96,6 +97,22 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
 }));
 
 jest.mock('@/components/app/data/hooks/useBFFContext');
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  fetchAuthenticatedUser: jest.fn().mockResolvedValue(undefined),
+  hydrateAuthenticatedUser: jest.fn().mockResolvedValue(undefined),
+  getAuthenticatedUser: jest.fn(() => ({
+    userId: 123,
+    email: 'test@example.com',
+    username: 'testuser',
+    country: 'US',
+  })),
+
+  getAuthenticatedHttpClient: jest.fn(() => ({
+    post: jest.fn().mockResolvedValue({ data: {} }),
+  })),
+
+}));
 
 const mockedUseBFFContext = useBFFContext as unknown as jest.Mock;
 
@@ -1019,8 +1036,8 @@ describe('PlanDetailsPage – Essentials navigation', () => {
     });
   });
 
-  it('PlanDetailsLogin (essentials): successful login → navigates back to /essentials/plan-details', async () => {
-    jest.clearAllMocks();
+  it('PlanDetailsLogin (essentials): successful login → navigates to /essentials/account-details', async () => {
+    // const user = userEvent.setup();
 
     // Provide safe constraints so form schema resolves
     (useFormValidationConstraints as jest.Mock).mockReturnValue({
@@ -1046,8 +1063,8 @@ describe('PlanDetailsPage – Essentials navigation', () => {
       },
     }));
 
-    // Mock useLoginMutation so mutate() immediately calls onSuccess -> triggers navigate()
-    const useLoginMutation = (await import('@/components/app/data/hooks/useLoginMutation')).default as unknown as jest.Mock;
+    // mock login success
+    const useLoginMutation = (await import('@/components/app/data/hooks/useLoginMutation')).default as jest.Mock;
 
     useLoginMutation.mockImplementation(({ onSuccess }: any) => ({
       mutate: jest.fn(() => onSuccess?.()),
@@ -1056,7 +1073,17 @@ describe('PlanDetailsPage – Essentials navigation', () => {
       isError: false,
     }));
 
-    // Render directly on the essentials login route
+    // ✅ mock checkout intent success (THIS WAS MISSING)
+    const useCreateCheckoutIntentMutation = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation'))
+      .default as jest.Mock;
+
+    useCreateCheckoutIntentMutation.mockImplementation(({ onSuccess }) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
     renderStepperRoute('/essentials/plan-details/login', {
       config: {},
       authenticatedUser: null,
@@ -1065,14 +1092,12 @@ describe('PlanDetailsPage – Essentials navigation', () => {
     // Click submit to trigger mutate -> onSuccess -> navigate()
     const submitButton = await screen.findByTestId('stepper-submit-button');
     await userEvent.click(submitButton);
-
-    // Assert the essentials-prefixed navigation happened
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/essentials/plan-details');
+      expect(mockNavigate).toHaveBeenCalledWith('/essentials/account-details');
     });
   });
 
-  it('PlanDetailsRegister (essentials): successful registration → navigates back to /essentials/plan-details', async () => {
+  it('PlanDetailsRegister (essentials): successful registration → navigates to /essentials/account-details', async () => {
     const user = userEvent.setup();
 
     // Registration success should navigate back to PlanDetails (essentials)
@@ -1096,7 +1121,7 @@ describe('PlanDetailsPage – Essentials navigation', () => {
     await user.click(screen.getByTestId('stepper-submit-button'));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/essentials/plan-details');
+      expect(mockNavigate).toHaveBeenCalledWith('/essentials/account-details');
     });
   });
 });
@@ -1134,5 +1159,236 @@ describe('PlanDetailsPage – Back button visibility', () => {
     expect(
       screen.getByRole('button', { name: /back/i }),
     ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loginMutation & registerMutation – success and error paths
+// ---------------------------------------------------------------------------
+
+describe('PlanDetailsPage – loginMutation success/error paths', () => {
+  let invalidateQueriesSpy: jest.SpyInstance;
+  let fetchQuerySpy: jest.SpyInstance;
+  let removeQueriesSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    invalidateQueriesSpy = jest.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue(undefined as any);
+    fetchQuerySpy = jest.spyOn(QueryClient.prototype, 'fetchQuery').mockResolvedValue(undefined as any);
+    removeQueriesSpy = jest.spyOn(QueryClient.prototype, 'removeQueries').mockImplementation(() => undefined);
+
+    (useFormValidationConstraints as jest.Mock).mockReturnValue({
+      data: { quantity: { min: 5, max: 30 } },
+    });
+
+    setupBFFContextMock();
+
+    checkoutFormStore.setState((state: any) => ({
+      ...state,
+      formData: {
+        ...state.formData,
+        [DataStoreKey.PlanDetails]: {
+          adminEmail: 'user@example.com',
+          password: 'Password123!',
+          fullName: 'Test User',
+          country: 'US',
+          quantity: 10,
+        },
+      },
+    }));
+  });
+
+  it('calls invalidateQueries and fetchQuery after successful login and checkout intent creation', async () => {
+    const useLoginMutationMock = (await import('@/components/app/data/hooks/useLoginMutation')).default as jest.Mock;
+    const useCreateCheckoutIntentMutationMock = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation')).default as jest.Mock;
+
+    // login success → immediately fires checkout intent
+    useLoginMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    // checkout intent success → triggers navigation and cache invalidation
+    useCreateCheckoutIntentMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsLogin, { config: {}, authenticatedUser: null });
+
+    await userEvent.click(await screen.findByTestId('stepper-submit-button'));
+
+    // Auth helpers called
+    const { fetchAuthenticatedUser, hydrateAuthenticatedUser, getAuthenticatedUser } = await import('@edx/frontend-platform/auth');
+    await waitFor(() => expect(fetchAuthenticatedUser).toHaveBeenCalled());
+    await waitFor(() => expect(hydrateAuthenticatedUser).toHaveBeenCalled());
+
+    // Cache should be invalidated with the logged-in user's id
+    await waitFor(() => expect(invalidateQueriesSpy).toHaveBeenCalled());
+    await waitFor(() => expect(removeQueriesSpy).toHaveBeenCalled());
+
+    // BFF context should be eagerly refetched by userId returned from getAuthenticatedUser
+    await waitFor(() => {
+      expect(getAuthenticatedUser).toHaveBeenCalled();
+      expect(fetchQuerySpy).toHaveBeenCalled();
+    });
+
+    // Navigation to Account Details
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(CheckoutPageRoute.AccountDetails);
+    });
+  });
+
+  it('sets password field error on login failure', async () => {
+    const useLoginMutationMock = (await import('@/components/app/data/hooks/useLoginMutation')).default as jest.Mock;
+
+    useLoginMutationMock.mockImplementation(({ onError }: any) => ({
+      mutate: jest.fn(() => onError?.('Invalid email or password')),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsLogin, { config: {}, authenticatedUser: null });
+
+    await userEvent.click(await screen.findByTestId('stepper-submit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid email or password')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('PlanDetailsPage – registerMutation success/error paths', () => {
+  let invalidateQueriesSpy: jest.SpyInstance;
+  let fetchQuerySpy: jest.SpyInstance;
+  let removeQueriesSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    invalidateQueriesSpy = jest.spyOn(QueryClient.prototype, 'invalidateQueries').mockResolvedValue(undefined as any);
+    fetchQuerySpy = jest.spyOn(QueryClient.prototype, 'fetchQuery').mockResolvedValue(undefined as any);
+    removeQueriesSpy = jest.spyOn(QueryClient.prototype, 'removeQueries').mockImplementation(() => undefined);
+
+    (useFormValidationConstraints as jest.Mock).mockReturnValue({
+      data: { quantity: { min: 5, max: 30 } },
+    });
+
+    const { useRecaptchaToken } = jest.requireMock('@/components/app/data');
+    (useRecaptchaToken as jest.Mock).mockReturnValue(
+      { getToken: jest.fn().mockResolvedValue('test-token'), isLoading: false, isReady: true },
+    );
+
+    setupBFFContextMock();
+
+    checkoutFormStore.setState((state: any) => ({
+      ...state,
+      formData: {
+        ...state.formData,
+        [DataStoreKey.PlanDetails]: {
+          adminEmail: 'newuser@example.com',
+          fullName: 'New User',
+          country: 'US',
+          quantity: 10,
+        },
+      },
+    }));
+  });
+
+  it('calls invalidateQueries and fetchQuery after successful registration and checkout intent creation', async () => {
+    const useRegisterMutationMock = (await import('@/components/app/data/hooks/useRegisterMutation')).default as jest.Mock;
+    const useCreateCheckoutIntentMutationMock = (await import('@/components/app/data/hooks/useCreateCheckoutIntentMutation')).default as jest.Mock;
+
+    useRegisterMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    useCreateCheckoutIntentMutationMock.mockImplementation(({ onSuccess }: any) => ({
+      mutate: jest.fn(() => onSuccess?.()),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsRegister);
+
+    await userEvent.type(screen.getByLabelText(/public username/i), 'newuser');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    const { fetchAuthenticatedUser, hydrateAuthenticatedUser, getAuthenticatedUser } = await import('@edx/frontend-platform/auth');
+    await waitFor(() => expect(fetchAuthenticatedUser).toHaveBeenCalled());
+    await waitFor(() => expect(hydrateAuthenticatedUser).toHaveBeenCalled());
+
+    await waitFor(() => expect(invalidateQueriesSpy).toHaveBeenCalled());
+    await waitFor(() => expect(removeQueriesSpy).toHaveBeenCalled());
+
+    await waitFor(() => {
+      expect(getAuthenticatedUser).toHaveBeenCalled();
+      expect(fetchQuerySpy).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(CheckoutPageRoute.AccountDetails);
+    });
+  });
+
+  it('sets adminEmail field error when server returns a validation-error for email', async () => {
+    const useRegisterMutationMock = (await import('@/components/app/data/hooks/useRegisterMutation')).default as jest.Mock;
+
+    useRegisterMutationMock.mockImplementation(({ onError }: any) => ({
+      mutate: jest.fn(() => onError?.('Registration failed', {
+        errorCode: 'validation-error',
+        email: [{ userMessage: 'Enter a valid email address.' }],
+      })),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsRegister);
+
+    await userEvent.type(screen.getByLabelText(/public username/i), 'newuser');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Enter a valid email address.')).toBeInTheDocument();
+    });
+  });
+
+  it('handles registration failure without email-specific validation error', async () => {
+    const useRegisterMutationMock = (await import('@/components/app/data/hooks/useRegisterMutation')).default as jest.Mock;
+    const mutateSpy = jest.fn();
+
+    useRegisterMutationMock.mockImplementation(({ onError }: any) => ({
+      mutate: mutateSpy.mockImplementation(() => onError?.('Registration failed')),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.PlanDetailsRegister);
+
+    await userEvent.type(screen.getByLabelText(/public username/i), 'newuser');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'Password123!');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'Password123!');
+    await userEvent.click(screen.getByTestId('stepper-submit-button'));
+
+    await waitFor(() => {
+      expect(mutateSpy).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText('Enter a valid email address.')).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith(CheckoutPageRoute.AccountDetails);
   });
 });


### PR DESCRIPTION

JIRA: https://2u-internal.atlassian.net/browse/ENT-11756

Description
1)When a user starts Essentials checkout from a Plan Details page and is not logged in and a new user, they are taken to the Register page.
2)After the user completes registration (all required fields valid and submitted successfully), the system must:
Create the user and log them in, and
3)Navigate them directly to the Account Details (Step 2) page of the Essentials checkout flow,
instead of sending them back to the Plan Details page.
4)This ensures a smooth flow: Plan Details → Register → Account Details (logged-in state) for new, authenticated users.


https://github.com/user-attachments/assets/0d3d5b73-835b-46c1-8a8c-b842ed42066e


https://github.com/user-attachments/assets/7d70a94f-1d2e-4b88-a311-cd37ebe3553c



 

