### PR TITLE
fix: prevent validation on initial load and retain errors on back nav…

### DIFF
--- a/src/components/account-details-page/AccountDetailsPage.tsx
+++ b/src/components/account-details-page/AccountDetailsPage.tsx
@@ -203,16 +203,20 @@ const AccountDetailsPage: React.FC = () => {
   // Restore validation errors when returning from back navigation
   useEffect(() => {
     const shouldRestoreValidation = sessionStorage.getItem(ACCOUNT_DETAILS_RESTORE_ERRORS_KEY) === 'true';
-    if (!shouldRestoreValidation || !hasPersistedAccountDetailsValues) {
-      return;
-    }
-
     let isActive = true;
+
+    if (!shouldRestoreValidation || !hasPersistedAccountDetailsValues) {
+      return () => {
+        isActive = false;
+      };
+    }
 
     const restoreValidationErrors = async () => {
       try {
         const result = await accountDetailsSchema.safeParseAsync(accountDetailsFormData);
-        if (!isActive || result.success) return;
+        if (!isActive || result.success) {
+          return;
+        }
 
         result.error.issues.forEach((issue) => {
           const fieldName = issue.path[0];
@@ -228,7 +232,9 @@ const AccountDetailsPage: React.FC = () => {
       }
     };
 
-    void restoreValidationErrors();
+    restoreValidationErrors().catch((error) => {
+      logError('Failed to restore validation errors', error);
+    });
 
     return () => {
       isActive = false;

--- a/src/components/account-details-page/AccountDetailsPage.tsx
+++ b/src/components/account-details-page/AccountDetailsPage.tsx
@@ -10,7 +10,6 @@ import {
 } from '@openedx/paragon';
 import { useQueryClient } from '@tanstack/react-query';
 import {
-  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -43,6 +42,8 @@ import { sendEnterpriseCheckoutPageEvent, sendEnterpriseCheckoutTrackingEvent } 
 import { isEssentialsFlow } from '../app/routes/loaders/utils';
 
 import AccountDetailsSubmitButton from './AccountDetailsSubmitButton';
+
+const ACCOUNT_DETAILS_RESTORE_ERRORS_KEY = 'accountDetailsRestoreErrors';
 
 const AccountDetailsPage: React.FC = () => {
   const { data: formValidationConstraints } = useFormValidationConstraints();
@@ -108,11 +109,10 @@ const AccountDetailsPage: React.FC = () => {
 
   const {
     handleSubmit,
-    formState: { isDirty: formIsDirty, isValid: formIsValid },
+    formState: { isDirty: formIsDirty, isValid: formIsValid, errors: formErrors },
     setError,
     reset: formReset,
     getValues,
-    trigger,
   } = form;
 
   const setCheckoutSessionClientSecret = useCheckoutFormStore((state) => state.setCheckoutSessionClientSecret);
@@ -199,35 +199,48 @@ const AccountDetailsPage: React.FC = () => {
   }, [formIsDirty, mutationIsSuccess, resetMutation]);
 
   const hasPersistedAccountDetailsValues = Object.keys(accountDetailsFormData).length > 0;
-  const hadPersistedValuesOnMount = useRef(hasPersistedAccountDetailsValues);
-  const persistedValuesOnMountRef = useRef(accountDetailsFormData);
-  const previousPathRef = useRef(location.pathname);
 
-  const restorePersistedValidationState = useCallback((values: Partial<AccountDetailsData>) => {
-    formReset(values);
-    trigger().catch(() => {});
-  }, [formReset, trigger]);
-
+  // Restore validation errors when returning from back navigation
   useEffect(() => {
-    if (!hadPersistedValuesOnMount.current) {
+    const shouldRestoreValidation = sessionStorage.getItem(ACCOUNT_DETAILS_RESTORE_ERRORS_KEY) === 'true';
+    if (!shouldRestoreValidation || !hasPersistedAccountDetailsValues) {
       return;
     }
-    restorePersistedValidationState(persistedValuesOnMountRef.current);
-  }, [restorePersistedValidationState]);
 
+    let isActive = true;
+
+    const restoreValidationErrors = async () => {
+      try {
+        const result = await accountDetailsSchema.safeParseAsync(accountDetailsFormData);
+        if (!isActive || result.success) return;
+
+        result.error.issues.forEach((issue) => {
+          const fieldName = issue.path[0];
+          if (typeof fieldName === 'string') {
+            setError(fieldName as keyof AccountDetailsData, {
+              type: 'manual',
+              message: issue.message,
+            });
+          }
+        });
+      } catch (error) {
+        logError('Failed to restore validation errors', error);
+      }
+    };
+
+    void restoreValidationErrors();
+
+    return () => {
+      isActive = false;
+    };
+  }, [accountDetailsFormData, accountDetailsSchema, hasPersistedAccountDetailsValues, setError]);
+
+  // Clear the restore flag when user starts editing (form becomes dirty)
   useEffect(() => {
-    const didPathChange = previousPathRef.current !== location.pathname;
-    const isAccountDetailsPath = (
-      location.pathname === CheckoutPageRoute.AccountDetails
-      || location.pathname === EssentialsPageRoute.AccountDetails
-    );
-
-    if (didPathChange && isAccountDetailsPath && hasPersistedAccountDetailsValues) {
-      restorePersistedValidationState(accountDetailsFormData);
+    if (formIsDirty) {
+      sessionStorage.removeItem(ACCOUNT_DETAILS_RESTORE_ERRORS_KEY);
     }
-
-    previousPathRef.current = location.pathname;
-  }, [accountDetailsFormData, hasPersistedAccountDetailsValues, location.pathname, restorePersistedValidationState]);
+  }, [formIsDirty]);
 
   const onSubmit = (data: AccountDetailsData) => {
     setFormData(DataStoreKey.AccountDetails, data);
@@ -261,6 +274,13 @@ const AccountDetailsPage: React.FC = () => {
   };
 
   const handleBackClick = () => {
+    const hasVisibleValidationErrors = Object.keys(formErrors).length > 0;
+    if (hasVisibleValidationErrors) {
+      sessionStorage.setItem(ACCOUNT_DETAILS_RESTORE_ERRORS_KEY, 'true');
+    } else {
+      sessionStorage.removeItem(ACCOUNT_DETAILS_RESTORE_ERRORS_KEY);
+    }
+
     setFormData(DataStoreKey.AccountDetails, {
       ...accountDetailsFormData,
       ...getValues(),

--- a/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
+++ b/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
@@ -13,8 +13,6 @@ import { checkoutFormStore } from '@/hooks/useCheckoutFormStore';
 import { sendEnterpriseCheckoutTrackingEvent } from '@/utils/common';
 import { renderStepperRoute } from '@/utils/tests';
 
-const ACCOUNT_DETAILS_RESTORE_ERRORS_KEY = 'accountDetailsRestoreErrors';
-
 jest.mock('@/utils/common', () => ({
   ...jest.requireActual('@/utils/common'),
   sendEnterpriseCheckoutTrackingEvent: jest.fn(),

--- a/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
+++ b/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
@@ -13,6 +13,8 @@ import { checkoutFormStore } from '@/hooks/useCheckoutFormStore';
 import { sendEnterpriseCheckoutTrackingEvent } from '@/utils/common';
 import { renderStepperRoute } from '@/utils/tests';
 
+const ACCOUNT_DETAILS_RESTORE_ERRORS_KEY = 'accountDetailsRestoreErrors';
+
 jest.mock('@/utils/common', () => ({
   ...jest.requireActual('@/utils/common'),
   sendEnterpriseCheckoutTrackingEvent: jest.fn(),
@@ -171,6 +173,27 @@ describe('AccountDetailsPage', () => {
     validateText('Create a custom URL for your team');
   });
 
+  it('does not show validation messages on first visit before user interaction', () => {
+    checkoutFormStore.setState((state) => ({
+      ...state,
+      formData: {
+        ...state.formData,
+        [DataStoreKey.AccountDetails]: {},
+      },
+    }));
+
+    renderStepperRoute(CheckoutPageRoute.AccountDetails, {
+      config: {},
+      authenticatedUser: {
+        userId: 12345,
+      },
+    });
+
+    // Verify that validation error messages are NOT displayed without user interaction
+    expect(screen.queryByText('Company name is required')).not.toBeInTheDocument();
+    expect(screen.queryByText('Only alphanumeric lowercase characters and hyphens are allowed.')).not.toBeInTheDocument();
+  });
+
   it('navigates back to plan details in essentials flow', async () => {
     const user = userEvent.setup();
     sessionStorage.setItem('isEssentials', 'true');
@@ -303,6 +326,14 @@ describe('AccountDetailsPage', () => {
       companyName: '',
       enterpriseSlug: 'invalid slug!',
     });
+
+    const firstRender = renderStepperRoute(CheckoutPageRoute.AccountDetails, {
+      config: {},
+      authenticatedUser: {
+        userId: 12345,
+      },
+    });
+    firstRender.unmount();
 
     renderStepperRoute(CheckoutPageRoute.AccountDetails, {
       config: {},


### PR DESCRIPTION
https://github.com/user-attachments/assets/93ace6fe-2236-4c5c-9815-51f4712a4ba7


Fixed validation behavior on the Account Details page to align with expected UX:

Prevented validation errors from showing on initial page load before user interaction
Ensured validation errors are displayed when the user attempts to continue with invalid or incomplete fields
Restored validation errors when navigating back to the Account Details page after entering invalid data

This resolves inconsistent validation behavior and ensures a smoother user experience across navigation flows.
