### PR TITLE
feat: 11756/SSP-Add authenticated user status to account details page

### DIFF
--- a/src/components/Stepper/StepperContent/AccountDetailsContent.tsx
+++ b/src/components/Stepper/StepperContent/AccountDetailsContent.tsx
@@ -1,7 +1,9 @@
-import {
+import { AppContext } from '@edx/frontend-platform/react';
+import { useContext } from 'react';
+
+import { AuthenticatedUserField,
   CompanyNameField,
-  CustomUrlField,
-} from '@/components/FormFields';
+  CustomUrlField } from '@/components/FormFields';
 
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -9,11 +11,21 @@ interface AccountDetailsContentProps {
   form: UseFormReturn<AccountDetailsData>;
 }
 
-const AccountDetailsContent = ({ form }: AccountDetailsContentProps) => (
-  <>
-    <CompanyNameField form={form} />
-    <CustomUrlField form={form} />
-  </>
-);
+const AccountDetailsContent = ({ form }: AccountDetailsContentProps) => {
+  const { authenticatedUser }: AppContextValue = useContext(AppContext);
+  return (
+    <>
+      {authenticatedUser
+            && (
+              <AuthenticatedUserField
+                adminEmail={authenticatedUser.email}
+                fullName={authenticatedUser.name || authenticatedUser.username}
+              />
+            ) }
+      <CompanyNameField form={form} />
+      <CustomUrlField form={form} />
+    </>
+  );
+};
 
 export default AccountDetailsContent;

--- a/src/components/Stepper/StepperContent/AccountDetailsContent.tsx
+++ b/src/components/Stepper/StepperContent/AccountDetailsContent.tsx
@@ -1,9 +1,11 @@
 import { AppContext } from '@edx/frontend-platform/react';
 import { useContext } from 'react';
 
-import { AuthenticatedUserField,
+import {
+  AuthenticatedUserField,
   CompanyNameField,
-  CustomUrlField } from '@/components/FormFields';
+  CustomUrlField,
+} from '@/components/FormFields';
 
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -15,13 +17,12 @@ const AccountDetailsContent = ({ form }: AccountDetailsContentProps) => {
   const { authenticatedUser }: AppContextValue = useContext(AppContext);
   return (
     <>
-      {authenticatedUser
-            && (
-              <AuthenticatedUserField
-                adminEmail={authenticatedUser.email}
-                fullName={authenticatedUser.name || authenticatedUser.username}
-              />
-            ) }
+      {authenticatedUser && (
+        <AuthenticatedUserField
+          adminEmail={authenticatedUser.email}
+          fullName={authenticatedUser.name || authenticatedUser.username}
+        />
+      )}
       <CompanyNameField form={form} />
       <CustomUrlField form={form} />
     </>

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -196,10 +196,6 @@ const PlanDetailsPage = () => {
         country: planDetailsFormData.country,
       });
       await invalidateCheckoutQueries(queryClient);
-      const userId = getAuthenticatedUser()?.userId;
-      if (userId) {
-        await queryClient.fetchQuery(queryBffContext(userId));
-      }
     },
     onError: (errorMessage) => {
       setIsSubmitting(false);
@@ -222,11 +218,7 @@ const PlanDetailsPage = () => {
       });
       // Now refresh context cache used by rootLoader/loaders
       await invalidateCheckoutQueries(queryClient);
-      // Optional hard guarantee: force a network read immediately
-      const userId = getAuthenticatedUser()?.userId;
-      if (userId) {
-        await queryClient.fetchQuery(queryBffContext(userId));
-      }
+
       try {
         sendEnterpriseCheckoutTrackingEvent({
           checkoutIntentId,

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -152,18 +152,22 @@ const PlanDetailsPage = () => {
 
   const createCheckoutIntentMutation = useCreateCheckoutIntentMutation({
     onSuccess: async () => {
-      // Refresh checkout context after the intent exists so downstream loaders don't reuse stale data.
-      const currentUserId = getAuthenticatedUser()?.userId;
-      await queryClientInvalidate(currentUserId);
-      if (currentUserId) {
-        await queryClient.fetchQuery({
-          ...queryBffContext(currentUserId),
-          staleTime: 0,
-        });
+      try {
+        // Refresh checkout context after the intent exists so downstream loaders don't reuse stale data.
+        const currentUserId = getAuthenticatedUser()?.userId;
+        await queryClientInvalidate(currentUserId);
+        if (currentUserId) {
+          await queryClient.fetchQuery({
+            ...queryBffContext(currentUserId),
+            staleTime: 0,
+          });
+        }
+      } catch (error) {
+        logError('Failed to refresh checkout context after intent creation', error);
+      } finally {
+        setIsSubmitting(false);
+        navigate(buildCheckoutPath(CheckoutPageRoute.AccountDetails));
       }
-
-      setIsSubmitting(false);
-      navigate(buildCheckoutPath(CheckoutPageRoute.AccountDetails));
     },
     onError: (errorData) => {
       setIsSubmitting(false);

--- a/src/components/plan-details-pages/PlanDetailsPage.tsx
+++ b/src/components/plan-details-pages/PlanDetailsPage.tsx
@@ -152,8 +152,15 @@ const PlanDetailsPage = () => {
 
   const createCheckoutIntentMutation = useCreateCheckoutIntentMutation({
     onSuccess: async () => {
-      // Invalidate BFF context queries so downstream pages see the new intent.
-      await queryClientInvalidate(authenticatedUser?.userId);
+      // Refresh checkout context after the intent exists so downstream loaders don't reuse stale data.
+      const currentUserId = getAuthenticatedUser()?.userId;
+      await queryClientInvalidate(currentUserId);
+      if (currentUserId) {
+        await queryClient.fetchQuery({
+          ...queryBffContext(currentUserId),
+          staleTime: 0,
+        });
+      }
 
       setIsSubmitting(false);
       navigate(buildCheckoutPath(CheckoutPageRoute.AccountDetails));

--- a/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
+++ b/src/components/plan-details-pages/tests/PlanDetailsPage.test.tsx
@@ -8,6 +8,7 @@ import { sendPageEvent } from '@edx/frontend-platform/analytics';
 
 import { useFormValidationConstraints } from '@/components/app/data';
 import useBFFContext from '@/components/app/data/hooks/useBFFContext';
+import { queryBffContext } from '@/components/app/data/queries/queries';
 import { camelCasedCheckoutContextResponseFactory } from '@/components/app/data/services/__factories__';
 import { validateFieldDetailed } from '@/components/app/data/services/validation';
 import { CheckoutPageRoute, CheckoutStepKey, CheckoutSubstepKey, DataStoreKey } from '@/constants/checkout';
@@ -1250,7 +1251,10 @@ describe('PlanDetailsPage – loginMutation success/error paths', () => {
     // BFF context should be eagerly refetched by userId returned from getAuthenticatedUser
     await waitFor(() => {
       expect(getAuthenticatedUser).toHaveBeenCalled();
-      expect(fetchQuerySpy).toHaveBeenCalled();
+      expect(fetchQuerySpy).toHaveBeenCalledWith(expect.objectContaining({
+        queryKey: queryBffContext(123).queryKey,
+        staleTime: 0,
+      }));
     });
 
     // Navigation to Account Details
@@ -1349,7 +1353,10 @@ describe('PlanDetailsPage – registerMutation success/error paths', () => {
 
     await waitFor(() => {
       expect(getAuthenticatedUser).toHaveBeenCalled();
-      expect(fetchQuerySpy).toHaveBeenCalled();
+      expect(fetchQuerySpy).toHaveBeenCalledWith(expect.objectContaining({
+        queryKey: queryBffContext(123).queryKey,
+        staleTime: 0,
+      }));
     });
 
     await waitFor(() => {


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-11756

When a user starts Essentials checkout from a Plan Details page and is not logged in and a new user, they are taken to the Register page.

After the user completes registration (all required fields valid and submitted successfully), the system must:

Create the user and log them in, and

Navigate them directly to the Account Details (Step 2) page of the Essentials checkout flow,

instead of sending them back to the Plan Details page.

This ensures a smooth flow: Plan Details → Register → Account Details (logged-in state) for new, authenticated users.

 https://github.com/adeltorocs/self-service-essentials-prototype
**Prototype**
<img width="1254" height="487" alt="image-20260403-071956" src="https://github.com/user-attachments/assets/5404a9bc-9708-45a0-962c-dfea22214a06" />


<img width="1869" height="859" alt="Apr23" src="https://github.com/user-attachments/assets/ebc3b491-afef-4a9b-8b25-3f849a6d5972" />


 