### PR TITLE
Ent 11786/ssp

### DIFF
--- a/src/components/FormFields/CompanyNameField.tsx
+++ b/src/components/FormFields/CompanyNameField.tsx
@@ -1,15 +1,18 @@
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Stack } from '@openedx/paragon';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
 import useBFFContext from '@/components/app/data/hooks/useBFFContext';
 import { FieldContainer } from '@/components/FieldContainer';
 import Field from '@/components/FormFields/Field';
+import { DataStoreKey } from '@/constants/checkout';
 import { PLAN_TYPE, TRACKED_FIELDS } from '@/constants/events';
+import { useCheckoutFormStore } from '@/hooks/useCheckoutFormStore';
 import useCurrentStep from '@/hooks/useCurrentStep';
 import { trackFieldBlur } from '@/hooks/useFieldTracking';
+import { findAvailableSlug, generateSlugFromCompanyName } from '@/utils/checkout';
 
 interface CompanyNameFieldProps {
   form: UseFormReturn<AccountDetailsData>
@@ -22,6 +25,69 @@ const CompanyNameField = ({ form }: CompanyNameFieldProps) => {
   const checkoutIntentId = bffContext?.checkoutIntent?.id ?? null;
   const checkoutIntentUuid = bffContext?.checkoutIntent?.uuid ?? null;
   const { currentStepKey, currentSubstepKey } = useCurrentStep();
+
+  const planDetailsFormData = useCheckoutFormStore((state) => state.formData[DataStoreKey.PlanDetails]);
+  const [isGeneratingSlug, setIsGeneratingSlug] = useState(false);
+
+  const handleCompanyNameBlur = async () => {
+    // Track field blur event
+    trackFieldBlur({
+      fieldName: TRACKED_FIELDS.COMPANY_NAME,
+      step: currentStepKey,
+      substep: currentSubstepKey,
+      checkoutIntentId,
+      checkoutIntentUuid,
+      additionalProperties: {
+        plan_type: PLAN_TYPE.TEAMS,
+      },
+    });
+
+    // Get the current company name value
+    const companyName = form.getValues('companyName');
+
+    // Clear slug if company name is empty or whitespace-only
+    if (!companyName || typeof companyName !== 'string' || companyName.trim().length === 0) {
+      form.setValue('enterpriseSlug', '', {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+      return;
+    }
+
+    // Don't generate if slug already has a value (to avoid overwriting user's previous selection)
+    const currentSlug = form.getValues('enterpriseSlug');
+    if (currentSlug && currentSlug.trim().length > 0) {
+      return;
+    }
+
+    try {
+      setIsGeneratingSlug(true);
+
+      // Generate base slug from company name
+      const baseSlug = generateSlugFromCompanyName(companyName, 30);
+
+      if (!baseSlug) {
+        return;
+      }
+
+      // Find an available slug (handles collisions)
+      const availableSlug = await findAvailableSlug(
+        baseSlug,
+        planDetailsFormData.adminEmail,
+        30,
+      );
+
+      // Populate the enterpriseSlug field
+      form.setValue('enterpriseSlug', availableSlug, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    } finally {
+      setIsGeneratingSlug(false);
+    }
+  };
 
   return (
     <FieldContainer>
@@ -48,16 +114,8 @@ const CompanyNameField = ({ form }: CompanyNameFieldProps) => {
             description: 'Placeholder for the company name input field',
           })}
           controlClassName="mr-0 mt-3"
-          onBlur={() => trackFieldBlur({
-            fieldName: TRACKED_FIELDS.COMPANY_NAME,
-            step: currentStepKey,
-            substep: currentSubstepKey,
-            checkoutIntentId,
-            checkoutIntentUuid,
-            additionalProperties: {
-              plan_type: PLAN_TYPE.TEAMS,
-            },
-          })}
+          onBlur={handleCompanyNameBlur}
+          disabled={isGeneratingSlug}
         />
       </Stack>
     </FieldContainer>

--- a/src/components/FormFields/CompanyNameField.tsx
+++ b/src/components/FormFields/CompanyNameField.tsx
@@ -74,7 +74,7 @@ const CompanyNameField = ({ form }: CompanyNameFieldProps) => {
       // Find an available slug (handles collisions)
       const availableSlug = await findAvailableSlug(
         baseSlug,
-        planDetailsFormData.adminEmail,
+        planDetailsFormData.adminEmail || '',
         30,
       );
 

--- a/src/components/FormFields/CustomUrlField.tsx
+++ b/src/components/FormFields/CustomUrlField.tsx
@@ -68,6 +68,8 @@ const CustomUrlField = ({ form }: CustomUrlFieldProps) => {
               },
               debounceMs: 500,
             })}
+            readOnly
+            disabled
           />
         </span>
       </div>

--- a/src/components/FormFields/CustomUrlField.tsx
+++ b/src/components/FormFields/CustomUrlField.tsx
@@ -69,7 +69,6 @@ const CustomUrlField = ({ form }: CustomUrlFieldProps) => {
               debounceMs: 500,
             })}
             readOnly
-            disabled
           />
         </span>
       </div>

--- a/src/components/FormFields/tests/CompanyNameField.test.tsx
+++ b/src/components/FormFields/tests/CompanyNameField.test.tsx
@@ -1,9 +1,11 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
 import { AppContext } from '@edx/frontend-platform/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+import { validateFieldDetailed } from '@/components/app/data/services/validation';
 import { CheckoutStepKey } from '@/constants/checkout';
 import { useCheckoutFormStore } from '@/hooks/useCheckoutFormStore';
 import { trackFieldBlur } from '@/hooks/useFieldTracking';
@@ -41,9 +43,12 @@ jest.mock('@/hooks/useCheckoutFormStore', () => ({
   useCheckoutFormStore: jest.fn(),
 }));
 
-jest.mock('@/utils/checkout', () => ({
-  findAvailableSlug: jest.fn(),
-  generateSlugFromCompanyName: jest.fn(),
+jest.mock('@/components/app/data/services/validation', () => ({
+  validateFieldDetailed: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
 }));
 
 jest.mock('@/hooks/useCurrentStep', () => ({
@@ -56,8 +61,8 @@ jest.mock('@/hooks/useCurrentStep', () => ({
 
 const mockTrackFieldBlur = trackFieldBlur as jest.Mock;
 const mockUseCheckoutFormStore = useCheckoutFormStore as unknown as jest.Mock;
-const mockFindAvailableSlug = findAvailableSlug as jest.Mock;
-const mockGenerateSlugFromCompanyName = generateSlugFromCompanyName as jest.Mock;
+const mockValidateFieldDetailed = validateFieldDetailed as jest.Mock;
+const mockLogError = logError as jest.Mock;
 
 const mockUseBFFContext = jest.fn(() => ({
   data: {
@@ -116,8 +121,10 @@ describe('CompanyNameField', () => {
         },
       },
     }));
-    mockGenerateSlugFromCompanyName.mockReturnValue('acme-corp');
-    mockFindAvailableSlug.mockResolvedValue('acme-corp-1');
+    mockValidateFieldDetailed.mockResolvedValue({
+      isValid: true,
+      validationDecisions: {},
+    });
   });
 
   it('renders the title correctly', () => {
@@ -204,15 +211,18 @@ describe('CompanyNameField', () => {
 
     screen.getByTestId('blur-trigger').click();
 
-    expect(mockGenerateSlugFromCompanyName).toHaveBeenCalledWith('Acme Corp', 30);
-    expect(mockFindAvailableSlug).toHaveBeenCalledWith('acme-corp', 'admin@example.com', 30);
-
-    await Promise.resolve();
-
-    expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp-1', {
-      shouldValidate: true,
-      shouldDirty: true,
-      shouldTouch: true,
+    await waitFor(() => {
+      expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
+        'enterpriseSlug',
+        'acme-corp',
+        { adminEmail: 'admin@example.com' },
+        true,
+      );
+      expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp', {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
     });
   });
 
@@ -230,14 +240,14 @@ describe('CompanyNameField', () => {
     );
 
     screen.getByTestId('blur-trigger').click();
-    await Promise.resolve();
-
-    expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', '', {
-      shouldValidate: true,
-      shouldDirty: true,
-      shouldTouch: true,
+    await waitFor(() => {
+      expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', '', {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
     });
-    expect(mockGenerateSlugFromCompanyName).not.toHaveBeenCalled();
+    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
   });
 
   it('does not generate a slug when enterpriseSlug already has a value', async () => {
@@ -254,15 +264,15 @@ describe('CompanyNameField', () => {
     );
 
     screen.getByTestId('blur-trigger').click();
-    await Promise.resolve();
+    await waitFor(() => {
+      expect(mockTrackFieldBlur).toHaveBeenCalled();
+    });
 
-    expect(mockGenerateSlugFromCompanyName).not.toHaveBeenCalled();
-    expect(mockFindAvailableSlug).not.toHaveBeenCalled();
+    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
     expect(form.setValue).not.toHaveBeenCalled();
   });
 
   it('does not call availability check when generated base slug is empty', async () => {
-    mockGenerateSlugFromCompanyName.mockReturnValue('');
     const form = createMockForm({ companyName: '!!!', enterpriseSlug: '' }) as any;
 
     render(
@@ -276,10 +286,11 @@ describe('CompanyNameField', () => {
     );
 
     screen.getByTestId('blur-trigger').click();
-    await Promise.resolve();
+    await waitFor(() => {
+      expect(mockTrackFieldBlur).toHaveBeenCalled();
+    });
 
-    expect(mockGenerateSlugFromCompanyName).toHaveBeenCalledWith('!!!', 30);
-    expect(mockFindAvailableSlug).not.toHaveBeenCalled();
+    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
     expect(form.setValue).not.toHaveBeenCalledWith('enterpriseSlug', expect.anything(), expect.anything());
   });
 
@@ -303,8 +314,223 @@ describe('CompanyNameField', () => {
     );
 
     screen.getByTestId('blur-trigger').click();
-    await Promise.resolve();
+    await waitFor(() => {
+      expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
+        'enterpriseSlug',
+        'acme-corp',
+        undefined,
+        true,
+      );
+    });
+  });
 
-    expect(mockFindAvailableSlug).toHaveBeenCalledWith('acme-corp', undefined, 30);
+  it('retries with numeric suffixes for taken and reserved slugs', async () => {
+    mockValidateFieldDetailed
+      .mockResolvedValueOnce({
+        isValid: false,
+        validationDecisions: {
+          enterpriseSlug: { errorCode: 'existing_enterprise_customer' },
+        },
+      })
+      .mockResolvedValueOnce({
+        isValid: false,
+        validationDecisions: {
+          enterpriseSlug: { errorCode: 'slug_reserved' },
+        },
+      })
+      .mockResolvedValueOnce({
+        isValid: true,
+        validationDecisions: {},
+      });
+
+    const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: '' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await waitFor(() => {
+      expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+        1,
+        'enterpriseSlug',
+        'acme-corp',
+        { adminEmail: 'admin@example.com' },
+        true,
+      );
+      expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+        2,
+        'enterpriseSlug',
+        'acme-corp-1',
+        { adminEmail: 'admin@example.com' },
+        true,
+      );
+      expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+        3,
+        'enterpriseSlug',
+        'acme-corp-2',
+        { adminEmail: 'admin@example.com' },
+        true,
+      );
+      expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp-2', {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    });
+  });
+
+  it('logs and returns the generated slug for non-retryable validation errors', async () => {
+    mockValidateFieldDetailed.mockResolvedValue({
+      isValid: false,
+      validationDecisions: {
+        enterpriseSlug: { errorCode: 'invalid_format' },
+      },
+    });
+
+    const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: '' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await waitFor(() => {
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Slug validation returned a non-retryable error for acme-corp: invalid_format',
+      );
+      expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp', {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    });
+  });
+
+  it('logs and returns the generated slug when validation throws', async () => {
+    mockValidateFieldDetailed.mockRejectedValue(new Error('network'));
+
+    const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: '' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await waitFor(() => {
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Slug validation failed for acme-corp',
+        expect.any(Error),
+      );
+      expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp', {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    });
+  });
+});
+
+describe('checkout slug helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty slug for invalid company names', () => {
+    expect(generateSlugFromCompanyName('')).toBe('');
+    expect(generateSlugFromCompanyName(null as unknown as string)).toBe('');
+  });
+
+  it('returns the base slug immediately when no slug is provided', async () => {
+    await expect(findAvailableSlug('')).resolves.toBe('');
+    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
+  });
+
+  it('returns the candidate when validation has no enterpriseSlug decision', async () => {
+    mockValidateFieldDetailed.mockResolvedValue({
+      isValid: false,
+      validationDecisions: {},
+    });
+
+    await expect(findAvailableSlug('acme-corp', 'admin@example.com')).resolves.toBe('acme-corp');
+
+    expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
+      'enterpriseSlug',
+      'acme-corp',
+      { adminEmail: 'admin@example.com' },
+      true,
+    );
+    expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it('truncates long base slugs when retrying with numeric suffixes', async () => {
+    mockValidateFieldDetailed
+      .mockResolvedValueOnce({
+        isValid: false,
+        validationDecisions: {
+          enterpriseSlug: { errorCode: 'existing_enterprise_customer' },
+        },
+      })
+      .mockResolvedValueOnce({
+        isValid: true,
+        validationDecisions: {},
+      });
+
+    await expect(findAvailableSlug('abcdefghijklmnopqrstuvwxyzabcd', 'admin@example.com')).resolves.toBe('abcdefghijklmnopqrstuvwxyzab-1');
+
+    expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+      1,
+      'enterpriseSlug',
+      'abcdefghijklmnopqrstuvwxyzabcd',
+      { adminEmail: 'admin@example.com' },
+      true,
+    );
+    expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+      2,
+      'enterpriseSlug',
+      'abcdefghijklmnopqrstuvwxyzab-1',
+      { adminEmail: 'admin@example.com' },
+      true,
+    );
+  });
+
+  it('logs and returns the last candidate when slug generation exceeds max attempts', async () => {
+    mockValidateFieldDetailed.mockResolvedValue({
+      isValid: false,
+      validationDecisions: {
+        enterpriseSlug: { errorCode: 'existing_enterprise_customer' },
+      },
+    });
+
+    await expect(findAvailableSlug('acme-corp', 'admin@example.com')).resolves.toBe('acme-corp-20');
+
+    expect(mockValidateFieldDetailed).toHaveBeenCalledTimes(20);
+    expect(mockValidateFieldDetailed).toHaveBeenLastCalledWith(
+      'enterpriseSlug',
+      'acme-corp-19',
+      { adminEmail: 'admin@example.com' },
+      true,
+    );
+    expect(mockLogError).toHaveBeenCalledWith(
+      'Slug generation exceeded max attempts for base slug acme-corp',
+    );
   });
 });

--- a/src/components/FormFields/tests/CompanyNameField.test.tsx
+++ b/src/components/FormFields/tests/CompanyNameField.test.tsx
@@ -260,4 +260,51 @@ describe('CompanyNameField', () => {
     expect(mockFindAvailableSlug).not.toHaveBeenCalled();
     expect(form.setValue).not.toHaveBeenCalled();
   });
+
+  it('does not call availability check when generated base slug is empty', async () => {
+    mockGenerateSlugFromCompanyName.mockReturnValue('');
+    const form = createMockForm({ companyName: '!!!', enterpriseSlug: '' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await Promise.resolve();
+
+    expect(mockGenerateSlugFromCompanyName).toHaveBeenCalledWith('!!!', 30);
+    expect(mockFindAvailableSlug).not.toHaveBeenCalled();
+    expect(form.setValue).not.toHaveBeenCalledWith('enterpriseSlug', expect.anything(), expect.anything());
+  });
+
+  it('passes undefined adminEmail to availability check when plan details email is unavailable', async () => {
+    mockUseCheckoutFormStore.mockImplementation((selector: any) => selector({
+      formData: {
+        PlanDetails: {},
+      },
+    }));
+
+    const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: '' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await Promise.resolve();
+
+    expect(mockFindAvailableSlug).toHaveBeenCalledWith('acme-corp', undefined, 30);
+  });
 });

--- a/src/components/FormFields/tests/CompanyNameField.test.tsx
+++ b/src/components/FormFields/tests/CompanyNameField.test.tsx
@@ -318,7 +318,7 @@ describe('CompanyNameField', () => {
       expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
         'enterpriseSlug',
         'acme-corp',
-        undefined,
+        { adminEmail: '' },
         true,
       );
     });

--- a/src/components/FormFields/tests/CompanyNameField.test.tsx
+++ b/src/components/FormFields/tests/CompanyNameField.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { validateFieldDetailed } from '@/components/app/data/services/validation';
+import fetchCheckoutValidation from '@/components/app/data/services/validation';
 import { CheckoutStepKey } from '@/constants/checkout';
 import { useCheckoutFormStore } from '@/hooks/useCheckoutFormStore';
 import { trackFieldBlur } from '@/hooks/useFieldTracking';
@@ -44,7 +44,8 @@ jest.mock('@/hooks/useCheckoutFormStore', () => ({
 }));
 
 jest.mock('@/components/app/data/services/validation', () => ({
-  validateFieldDetailed: jest.fn(),
+  __esModule: true,
+  default: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -61,7 +62,7 @@ jest.mock('@/hooks/useCurrentStep', () => ({
 
 const mockTrackFieldBlur = trackFieldBlur as jest.Mock;
 const mockUseCheckoutFormStore = useCheckoutFormStore as unknown as jest.Mock;
-const mockValidateFieldDetailed = validateFieldDetailed as jest.Mock;
+const mockFetchCheckoutValidation = fetchCheckoutValidation as jest.Mock;
 const mockLogError = logError as jest.Mock;
 
 const mockUseBFFContext = jest.fn(() => ({
@@ -121,8 +122,7 @@ describe('CompanyNameField', () => {
         },
       },
     }));
-    mockValidateFieldDetailed.mockResolvedValue({
-      isValid: true,
+    mockFetchCheckoutValidation.mockResolvedValue({
       validationDecisions: {},
     });
   });
@@ -212,12 +212,10 @@ describe('CompanyNameField', () => {
     screen.getByTestId('blur-trigger').click();
 
     await waitFor(() => {
-      expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
-        'enterpriseSlug',
-        'acme-corp',
-        { adminEmail: 'admin@example.com' },
-        true,
-      );
+      expect(mockFetchCheckoutValidation).toHaveBeenCalledWith({
+        enterprise_slug: 'acme-corp',
+        admin_email: 'admin@example.com',
+      });
       expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp', {
         shouldValidate: true,
         shouldDirty: true,
@@ -247,7 +245,7 @@ describe('CompanyNameField', () => {
         shouldTouch: true,
       });
     });
-    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
+    expect(mockFetchCheckoutValidation).not.toHaveBeenCalled();
   });
 
   it('does not generate a slug when enterpriseSlug already has a value', async () => {
@@ -268,7 +266,7 @@ describe('CompanyNameField', () => {
       expect(mockTrackFieldBlur).toHaveBeenCalled();
     });
 
-    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
+    expect(mockFetchCheckoutValidation).not.toHaveBeenCalled();
     expect(form.setValue).not.toHaveBeenCalled();
   });
 
@@ -290,7 +288,7 @@ describe('CompanyNameField', () => {
       expect(mockTrackFieldBlur).toHaveBeenCalled();
     });
 
-    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
+    expect(mockFetchCheckoutValidation).not.toHaveBeenCalled();
     expect(form.setValue).not.toHaveBeenCalledWith('enterpriseSlug', expect.anything(), expect.anything());
   });
 
@@ -315,31 +313,26 @@ describe('CompanyNameField', () => {
 
     screen.getByTestId('blur-trigger').click();
     await waitFor(() => {
-      expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
-        'enterpriseSlug',
-        'acme-corp',
-        { adminEmail: '' },
-        true,
-      );
+      expect(mockFetchCheckoutValidation).toHaveBeenCalledWith({
+        enterprise_slug: 'acme-corp',
+        admin_email: '',
+      });
     });
   });
 
   it('retries with numeric suffixes for taken and reserved slugs', async () => {
-    mockValidateFieldDetailed
+    mockFetchCheckoutValidation
       .mockResolvedValueOnce({
-        isValid: false,
         validationDecisions: {
           enterpriseSlug: { errorCode: 'existing_enterprise_customer' },
         },
       })
       .mockResolvedValueOnce({
-        isValid: false,
         validationDecisions: {
           enterpriseSlug: { errorCode: 'slug_reserved' },
         },
       })
       .mockResolvedValueOnce({
-        isValid: true,
         validationDecisions: {},
       });
 
@@ -357,26 +350,26 @@ describe('CompanyNameField', () => {
 
     screen.getByTestId('blur-trigger').click();
     await waitFor(() => {
-      expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+      expect(mockFetchCheckoutValidation).toHaveBeenNthCalledWith(
         1,
-        'enterpriseSlug',
-        'acme-corp',
-        { adminEmail: 'admin@example.com' },
-        true,
+        {
+          enterprise_slug: 'acme-corp',
+          admin_email: 'admin@example.com',
+        },
       );
-      expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+      expect(mockFetchCheckoutValidation).toHaveBeenNthCalledWith(
         2,
-        'enterpriseSlug',
-        'acme-corp-1',
-        { adminEmail: 'admin@example.com' },
-        true,
+        {
+          enterprise_slug: 'acme-corp-1',
+          admin_email: 'admin@example.com',
+        },
       );
-      expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+      expect(mockFetchCheckoutValidation).toHaveBeenNthCalledWith(
         3,
-        'enterpriseSlug',
-        'acme-corp-2',
-        { adminEmail: 'admin@example.com' },
-        true,
+        {
+          enterprise_slug: 'acme-corp-2',
+          admin_email: 'admin@example.com',
+        },
       );
       expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp-2', {
         shouldValidate: true,
@@ -387,8 +380,7 @@ describe('CompanyNameField', () => {
   });
 
   it('logs and returns the generated slug for non-retryable validation errors', async () => {
-    mockValidateFieldDetailed.mockResolvedValue({
-      isValid: false,
+    mockFetchCheckoutValidation.mockResolvedValue({
       validationDecisions: {
         enterpriseSlug: { errorCode: 'invalid_format' },
       },
@@ -420,7 +412,7 @@ describe('CompanyNameField', () => {
   });
 
   it('logs and returns the generated slug when validation throws', async () => {
-    mockValidateFieldDetailed.mockRejectedValue(new Error('network'));
+    mockFetchCheckoutValidation.mockRejectedValue(new Error('network'));
 
     const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: '' }) as any;
 
@@ -461,74 +453,66 @@ describe('checkout slug helpers', () => {
 
   it('returns the base slug immediately when no slug is provided', async () => {
     await expect(findAvailableSlug('')).resolves.toBe('');
-    expect(mockValidateFieldDetailed).not.toHaveBeenCalled();
+    expect(mockFetchCheckoutValidation).not.toHaveBeenCalled();
   });
 
   it('returns the candidate when validation has no enterpriseSlug decision', async () => {
-    mockValidateFieldDetailed.mockResolvedValue({
-      isValid: false,
+    mockFetchCheckoutValidation.mockResolvedValue({
       validationDecisions: {},
     });
 
     await expect(findAvailableSlug('acme-corp', 'admin@example.com')).resolves.toBe('acme-corp');
 
-    expect(mockValidateFieldDetailed).toHaveBeenCalledWith(
-      'enterpriseSlug',
-      'acme-corp',
-      { adminEmail: 'admin@example.com' },
-      true,
-    );
+    expect(mockFetchCheckoutValidation).toHaveBeenCalledWith({
+      enterprise_slug: 'acme-corp',
+      admin_email: 'admin@example.com',
+    });
     expect(mockLogError).not.toHaveBeenCalled();
   });
 
   it('truncates long base slugs when retrying with numeric suffixes', async () => {
-    mockValidateFieldDetailed
+    mockFetchCheckoutValidation
       .mockResolvedValueOnce({
-        isValid: false,
         validationDecisions: {
           enterpriseSlug: { errorCode: 'existing_enterprise_customer' },
         },
       })
       .mockResolvedValueOnce({
-        isValid: true,
         validationDecisions: {},
       });
 
     await expect(findAvailableSlug('abcdefghijklmnopqrstuvwxyzabcd', 'admin@example.com')).resolves.toBe('abcdefghijklmnopqrstuvwxyzab-1');
 
-    expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+    expect(mockFetchCheckoutValidation).toHaveBeenNthCalledWith(
       1,
-      'enterpriseSlug',
-      'abcdefghijklmnopqrstuvwxyzabcd',
-      { adminEmail: 'admin@example.com' },
-      true,
+      {
+        enterprise_slug: 'abcdefghijklmnopqrstuvwxyzabcd',
+        admin_email: 'admin@example.com',
+      },
     );
-    expect(mockValidateFieldDetailed).toHaveBeenNthCalledWith(
+    expect(mockFetchCheckoutValidation).toHaveBeenNthCalledWith(
       2,
-      'enterpriseSlug',
-      'abcdefghijklmnopqrstuvwxyzab-1',
-      { adminEmail: 'admin@example.com' },
-      true,
+      {
+        enterprise_slug: 'abcdefghijklmnopqrstuvwxyzab-1',
+        admin_email: 'admin@example.com',
+      },
     );
   });
 
   it('logs and returns the last candidate when slug generation exceeds max attempts', async () => {
-    mockValidateFieldDetailed.mockResolvedValue({
-      isValid: false,
+    mockFetchCheckoutValidation.mockResolvedValue({
       validationDecisions: {
         enterpriseSlug: { errorCode: 'existing_enterprise_customer' },
       },
     });
 
-    await expect(findAvailableSlug('acme-corp', 'admin@example.com')).resolves.toBe('acme-corp-20');
+    await expect(findAvailableSlug('acme-corp', 'admin@example.com')).resolves.toBe('acme-corp-19');
 
-    expect(mockValidateFieldDetailed).toHaveBeenCalledTimes(20);
-    expect(mockValidateFieldDetailed).toHaveBeenLastCalledWith(
-      'enterpriseSlug',
-      'acme-corp-19',
-      { adminEmail: 'admin@example.com' },
-      true,
-    );
+    expect(mockFetchCheckoutValidation).toHaveBeenCalledTimes(20);
+    expect(mockFetchCheckoutValidation).toHaveBeenLastCalledWith({
+      enterprise_slug: 'acme-corp-19',
+      admin_email: 'admin@example.com',
+    });
     expect(mockLogError).toHaveBeenCalledWith(
       'Slug generation exceeded max attempts for base slug acme-corp',
     );

--- a/src/components/FormFields/tests/CompanyNameField.test.tsx
+++ b/src/components/FormFields/tests/CompanyNameField.test.tsx
@@ -5,25 +5,47 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { CheckoutStepKey } from '@/constants/checkout';
+import { useCheckoutFormStore } from '@/hooks/useCheckoutFormStore';
 import { trackFieldBlur } from '@/hooks/useFieldTracking';
+import { findAvailableSlug, generateSlugFromCompanyName } from '@/utils/checkout';
 
 import CompanyNameField from '../CompanyNameField';
 
-// Mock the form object
-const createMockForm = (errors = {}) => ({
+const createMockForm = ({
+  errors = {},
+  companyName = 'Acme Corp',
+  enterpriseSlug = '',
+} = {}) => ({
   formState: {
     errors,
     touchedFields: { companyName: true },
   },
   register: jest.fn().mockReturnValue({}),
+  getValues: jest.fn((fieldName: string) => {
+    if (fieldName === 'companyName') {
+      return companyName;
+    }
+    if (fieldName === 'enterpriseSlug') {
+      return enterpriseSlug;
+    }
+    return undefined;
+  }),
+  setValue: jest.fn(),
 });
 
-// Mock tracking
 jest.mock('@/hooks/useFieldTracking', () => ({
   trackFieldBlur: jest.fn(),
 }));
 
-// Mock useCurrentStep
+jest.mock('@/hooks/useCheckoutFormStore', () => ({
+  useCheckoutFormStore: jest.fn(),
+}));
+
+jest.mock('@/utils/checkout', () => ({
+  findAvailableSlug: jest.fn(),
+  generateSlugFromCompanyName: jest.fn(),
+}));
+
 jest.mock('@/hooks/useCurrentStep', () => ({
   __esModule: true,
   default: jest.fn(() => ({
@@ -33,8 +55,10 @@ jest.mock('@/hooks/useCurrentStep', () => ({
 }));
 
 const mockTrackFieldBlur = trackFieldBlur as jest.Mock;
+const mockUseCheckoutFormStore = useCheckoutFormStore as unknown as jest.Mock;
+const mockFindAvailableSlug = findAvailableSlug as jest.Mock;
+const mockGenerateSlugFromCompanyName = generateSlugFromCompanyName as jest.Mock;
 
-// Mock BFF context hook
 const mockUseBFFContext = jest.fn(() => ({
   data: {
     checkoutIntent: { id: 123 },
@@ -47,12 +71,13 @@ jest.mock('@/components/app/data/hooks/useBFFContext', () => ({
 
 jest.mock('@/components/FormFields/Field', () => ({
   __esModule: true,
-  default: ({ floatingLabel, placeholder, form, name, onBlur }) => {
+  default: ({ floatingLabel, placeholder, form, name, onBlur, disabled }) => {
     const error = form?.formState?.errors[name];
     return (
       <div data-testid="field-mock">
         <div data-testid="floating-label">{floatingLabel}</div>
         <div data-testid="placeholder">{placeholder}</div>
+        <div data-testid="disabled-state">{String(Boolean(disabled))}</div>
         {error && <div data-testid="error-message">{error.message}</div>}
         <button type="button" onClick={onBlur} data-testid="blur-trigger">Trigger Blur</button>
       </div>
@@ -72,11 +97,11 @@ describe('CompanyNameField', () => {
     administrator: false,
   };
 
-  const renderComponent = (errors = {}) => render(
+  const renderComponent = (formOptions = {}) => render(
     <QueryClientProvider client={queryClient}>
       <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
         <IntlProvider locale="en">
-          <CompanyNameField form={createMockForm(errors) as any} />
+          <CompanyNameField form={createMockForm(formOptions) as any} />
         </IntlProvider>
       </AppContext.Provider>
     </QueryClientProvider>,
@@ -84,6 +109,15 @@ describe('CompanyNameField', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseCheckoutFormStore.mockImplementation((selector: any) => selector({
+      formData: {
+        PlanDetails: {
+          adminEmail: 'admin@example.com',
+        },
+      },
+    }));
+    mockGenerateSlugFromCompanyName.mockReturnValue('acme-corp');
+    mockFindAvailableSlug.mockResolvedValue('acme-corp-1');
   });
 
   it('renders the title correctly', () => {
@@ -99,9 +133,11 @@ describe('CompanyNameField', () => {
 
   it('displays validation error when companyName is invalid', () => {
     renderComponent({
-      companyName: {
-        type: 'required',
-        message: 'Company name is required',
+      errors: {
+        companyName: {
+          type: 'required',
+          message: 'Company name is required',
+        },
       },
     });
     expect(screen.getByTestId('error-message')).toHaveTextContent('Company name is required');
@@ -151,5 +187,77 @@ describe('CompanyNameField', () => {
     expect(mockTrackFieldBlur).toHaveBeenCalledWith(expect.objectContaining({
       checkoutIntentId: null,
     }));
+  });
+
+  it('generates and sets an available slug when company name is blurred and slug is empty', async () => {
+    const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: '' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+
+    expect(mockGenerateSlugFromCompanyName).toHaveBeenCalledWith('Acme Corp', 30);
+    expect(mockFindAvailableSlug).toHaveBeenCalledWith('acme-corp', 'admin@example.com', 30);
+
+    await Promise.resolve();
+
+    expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', 'acme-corp-1', {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    });
+  });
+
+  it('clears the slug when company name is blank on blur', async () => {
+    const form = createMockForm({ companyName: '   ', enterpriseSlug: 'existing-slug' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await Promise.resolve();
+
+    expect(form.setValue).toHaveBeenCalledWith('enterpriseSlug', '', {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    });
+    expect(mockGenerateSlugFromCompanyName).not.toHaveBeenCalled();
+  });
+
+  it('does not generate a slug when enterpriseSlug already has a value', async () => {
+    const form = createMockForm({ companyName: 'Acme Corp', enterpriseSlug: 'chosen-slug' }) as any;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+          <IntlProvider locale="en">
+            <CompanyNameField form={form} />
+          </IntlProvider>
+        </AppContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    screen.getByTestId('blur-trigger').click();
+    await Promise.resolve();
+
+    expect(mockGenerateSlugFromCompanyName).not.toHaveBeenCalled();
+    expect(mockFindAvailableSlug).not.toHaveBeenCalled();
+    expect(form.setValue).not.toHaveBeenCalled();
   });
 });

--- a/src/components/FormFields/tests/CustomUrlField.test.tsx
+++ b/src/components/FormFields/tests/CustomUrlField.test.tsx
@@ -35,10 +35,12 @@ jest.mock('@/components/app/data/hooks/useBFFContext', () => ({
 
 jest.mock('@/components/FormFields/Field', () => ({
   __esModule: true,
-  default: ({ floatingLabel, placeholder, onBlur }) => (
+  default: ({ floatingLabel, placeholder, onBlur, readOnly, disabled }) => (
     <div data-testid="field-mock">
       <div data-testid="floating-label">{floatingLabel}</div>
       <div data-testid="placeholder">{placeholder}</div>
+      <div data-testid="readonly-state">{String(Boolean(readOnly))}</div>
+      <div data-testid="disabled-state">{String(Boolean(disabled))}</div>
       <button type="button" onClick={onBlur} data-testid="blur-trigger">Trigger Blur</button>
     </div>
   ),
@@ -89,6 +91,24 @@ describe('CustomUrlField', () => {
     expect(mockTrackDebouncedFieldBlur).toHaveBeenCalledWith(expect.objectContaining({
       fieldName: 'urlSlug',
       step: CheckoutStepKey.AccountDetails,
+    }));
+  });
+
+  it('renders the field as read-only and disabled', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('readonly-state')).toHaveTextContent('true');
+    expect(screen.getByTestId('disabled-state')).toHaveTextContent('true');
+  });
+
+  it('passes the current slug value in the tracking payload', () => {
+    renderComponent();
+    screen.getByTestId('blur-trigger').click();
+
+    expect(mockTrackDebouncedFieldBlur).toHaveBeenCalledWith(expect.objectContaining({
+      additionalProperties: expect.objectContaining({
+        org_slug: 'test-slug',
+      }),
     }));
   });
 });

--- a/src/components/FormFields/tests/CustomUrlField.test.tsx
+++ b/src/components/FormFields/tests/CustomUrlField.test.tsx
@@ -94,11 +94,11 @@ describe('CustomUrlField', () => {
     }));
   });
 
-  it('renders the field as read-only and disabled', () => {
+  it('renders the field as read-only', () => {
     renderComponent();
 
     expect(screen.getByTestId('readonly-state')).toHaveTextContent('true');
-    expect(screen.getByTestId('disabled-state')).toHaveTextContent('true');
+    expect(screen.getByTestId('disabled-state')).toHaveTextContent('false');
   });
 
   it('passes the current slug value in the tracking payload', () => {

--- a/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
+++ b/src/components/account-details-page/tests/AccountDetailsPage.test.tsx
@@ -244,16 +244,12 @@ describe('AccountDetailsPage', () => {
     });
 
     const companyNameInput = screen.getByPlaceholderText('Enter your company name');
-    const enterpriseSlugInput = screen.getByPlaceholderText('URL name');
 
     await user.click(companyNameInput);
-    await user.click(enterpriseSlugInput);
-    await user.type(enterpriseSlugInput, 'invalid slug!');
     await user.tab();
 
     await waitFor(() => {
       expect(screen.getByText('Company name is required')).toBeInTheDocument();
-      expect(screen.getByText('Only alphanumeric lowercase characters and hyphens are allowed.')).toBeInTheDocument();
     });
   });
 
@@ -277,22 +273,18 @@ describe('AccountDetailsPage', () => {
     });
 
     const companyNameInput = screen.getByPlaceholderText('Enter your company name');
-    const enterpriseSlugInput = screen.getByPlaceholderText('URL name');
 
     await user.click(companyNameInput);
-    await user.click(enterpriseSlugInput);
-    await user.type(enterpriseSlugInput, 'invalid slug!');
     await user.tab();
 
     await waitFor(() => {
       expect(screen.getByText('Company name is required')).toBeInTheDocument();
-      expect(screen.getByText('Only alphanumeric lowercase characters and hyphens are allowed.')).toBeInTheDocument();
     });
 
     sessionStorage.removeItem('isEssentials');
   });
 
-  it('persists touched account details values on back and restores validation on revisit', async () => {
+  it('persists cleared slug state on back and restores company-name validation on revisit', async () => {
     const user = userEvent.setup();
 
     checkoutFormStore.setState((state) => ({
@@ -303,7 +295,7 @@ describe('AccountDetailsPage', () => {
       },
     }));
 
-    renderStepperRoute(CheckoutPageRoute.AccountDetails, {
+    const initialRender = renderStepperRoute(CheckoutPageRoute.AccountDetails, {
       config: {},
       authenticatedUser: {
         userId: 12345,
@@ -311,27 +303,18 @@ describe('AccountDetailsPage', () => {
     });
 
     const companyNameInput = screen.getByPlaceholderText('Enter your company name');
-    const enterpriseSlugInput = screen.getByPlaceholderText('URL name');
 
     await user.click(companyNameInput);
-    await user.click(enterpriseSlugInput);
-    await user.type(enterpriseSlugInput, 'invalid slug!');
-    await user.click(companyNameInput);
+    await user.tab();
 
     await user.click(screen.getByRole('button', { name: 'Back' }));
 
     expect(checkoutFormStore.getState().formData[DataStoreKey.AccountDetails]).toEqual({
       companyName: '',
-      enterpriseSlug: 'invalid slug!',
+      enterpriseSlug: '',
     });
 
-    const firstRender = renderStepperRoute(CheckoutPageRoute.AccountDetails, {
-      config: {},
-      authenticatedUser: {
-        userId: 12345,
-      },
-    });
-    firstRender.unmount();
+    initialRender.unmount();
 
     renderStepperRoute(CheckoutPageRoute.AccountDetails, {
       config: {},
@@ -342,8 +325,8 @@ describe('AccountDetailsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Company name is required')).toBeInTheDocument();
-      expect(screen.getByText('Only alphanumeric lowercase characters and hyphens are allowed.')).toBeInTheDocument();
     });
+    // formText helper is expected to be present; slug is correctly cleared
   });
 
   it('navigates to essentials billing details on successful checkout session creation in essentials flow', () => {

--- a/src/utils/checkout.ts
+++ b/src/utils/checkout.ts
@@ -100,9 +100,6 @@ export const generateSlugFromCompanyName = (
   // Replace spaces and non-alphanumeric characters with a single dash
   slug = slug.replace(/[^a-z0-9]+/g, '-');
 
-  // Collapse multiple consecutive dashes into one
-  slug = slug.replace(/-+/g, '-');
-
   // Trim leading and trailing dashes
   slug = slug.replace(/^-+|-+$/g, '');
 

--- a/src/utils/checkout.ts
+++ b/src/utils/checkout.ts
@@ -1,7 +1,7 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { Entries } from 'type-fest';
 
-import { validateFieldDetailed } from '@/components/app/data/services/validation';
+import fetchCheckoutValidation from '@/components/app/data/services/validation';
 import {
   CheckoutPageDetails,
   CheckoutStepByKey,
@@ -143,6 +143,18 @@ export const findAvailableSlug = async (
 
   const maxAttempts = 20; // Safety limit to prevent long client-side retry loops
 
+  const validateSlugCandidate = async (candidateSlug: string) => {
+    const response = await fetchCheckoutValidation({
+      enterprise_slug: candidateSlug,
+      admin_email: adminEmail || '',
+    });
+    const validationDecisions = response?.validationDecisions ?? {};
+    return {
+      isValid: !validationDecisions.enterpriseSlug,
+      validationDecisions,
+    };
+  };
+
   const nextCandidateForSuffix = (suffix: number): string => {
     const suffixStr = `-${suffix}`;
     const maxBaseLength = maxLength - suffixStr.length;
@@ -160,19 +172,15 @@ export const findAvailableSlug = async (
     candidateSlug: string,
     suffix: number,
     attempt: number,
+    lastValidatedCandidate: string = candidateSlug,
   ): Promise<string> => {
     if (attempt >= maxAttempts) {
       logError(`Slug generation exceeded max attempts for base slug ${baseSlug}`);
-      return candidateSlug;
+      return lastValidatedCandidate;
     }
 
     try {
-      const { isValid, validationDecisions } = await validateFieldDetailed(
-        'enterpriseSlug',
-        candidateSlug,
-        { adminEmail: adminEmail || '' },
-        true, // forceValidate to bypass cache
-      );
+      const { isValid, validationDecisions } = await validateSlugCandidate(candidateSlug);
 
       // If valid (no error), we found an available slug
       if (isValid || !validationDecisions?.enterpriseSlug) {
@@ -188,7 +196,7 @@ export const findAvailableSlug = async (
       }
 
       const nextSuffix = suffix + 1;
-      return await resolveCandidate(nextCandidateForSuffix(nextSuffix), nextSuffix, attempt + 1);
+      return await resolveCandidate(nextCandidateForSuffix(nextSuffix), nextSuffix, attempt + 1, candidateSlug);
     } catch (error) {
       logError(`Slug validation failed for ${candidateSlug}`, error);
       return candidateSlug;

--- a/src/utils/checkout.ts
+++ b/src/utils/checkout.ts
@@ -1,5 +1,7 @@
+import { logError } from '@edx/frontend-platform/logging';
 import { Entries } from 'type-fest';
 
+import { validateFieldDetailed } from '@/components/app/data/services/validation';
 import {
   CheckoutPageDetails,
   CheckoutStepByKey,
@@ -64,4 +66,134 @@ export const extractPriceId = (pricing: CheckoutContextPricing): CheckoutContext
   }
   const matched = extractPriceObject(pricing);
   return matched?.id ?? null;
+};
+
+/**
+ * Generates a URL slug from a company name following specific rules:
+ * - Converts to lowercase
+ * - Replaces spaces and non-alphanumeric characters with a single dash (-)
+ * - Collapses multiple consecutive dashes into one
+ * - Trims leading/trailing dashes
+ * - Enforces maximum length of 30 characters
+ * - Allowed characters: [a-z0-9-]
+ *
+ * @param companyName - The company name to convert to a slug
+ * @param maxLength - Maximum length for the slug (default: 30)
+ * @returns The generated slug, or empty string if input is invalid
+ *
+ * @example
+ * generateSlugFromCompanyName('ACME, Inc.') // returns 'acme-inc'
+ * generateSlugFromCompanyName('My  Company!!!') // returns 'my-company'
+ * generateSlugFromCompanyName('Test & Demo Corp.') // returns 'test-demo-corp'
+ */
+export const generateSlugFromCompanyName = (
+  companyName: string,
+  maxLength: number = 30,
+): string => {
+  if (!companyName || typeof companyName !== 'string') {
+    return '';
+  }
+
+  // Convert to lowercase
+  let slug = companyName.toLowerCase();
+
+  // Replace spaces and non-alphanumeric characters with a single dash
+  slug = slug.replace(/[^a-z0-9]+/g, '-');
+
+  // Collapse multiple consecutive dashes into one
+  slug = slug.replace(/-+/g, '-');
+
+  // Trim leading and trailing dashes
+  slug = slug.replace(/^-+|-+$/g, '');
+
+  // Enforce max length
+  if (slug.length > maxLength) {
+    slug = slug.substring(0, maxLength);
+    // Re-trim trailing dash in case truncation created one
+    slug = slug.replace(/-+$/, '');
+  }
+
+  return slug;
+};
+
+/**
+ * Finds an available enterprise slug by validating against the backend API
+ * and handling collisions with numeric suffixes.
+ *
+ * If the initial slug is taken, appends incremental numeric suffixes (-1, -2, -3, etc.)
+ * until an available slug is found. Respects the maximum length constraint.
+ *
+ * @param baseSlug - The initial slug to validate
+ * @param adminEmail - The admin email to include in validation (optional)
+ * @param maxLength - Maximum length for the slug (default: 30)
+ * @returns A promise that resolves to an available slug, or the original slug if validation fails
+ *
+ * @example
+ * await findAvailableSlug('acme-inc', 'admin@acme.com')
+ * // If 'acme-inc' is taken, tries 'acme-inc-1', then 'acme-inc-2', etc.
+ */
+export const findAvailableSlug = async (
+  baseSlug: string,
+  adminEmail?: string,
+  maxLength: number = 30,
+): Promise<string> => {
+  if (!baseSlug) {
+    return baseSlug;
+  }
+
+  const maxAttempts = 20; // Safety limit to prevent long client-side retry loops
+
+  const nextCandidateForSuffix = (suffix: number): string => {
+    const suffixStr = `-${suffix}`;
+    const maxBaseLength = maxLength - suffixStr.length;
+
+    let truncatedBase = baseSlug;
+    if (baseSlug.length > maxBaseLength) {
+      truncatedBase = baseSlug.substring(0, maxBaseLength);
+      truncatedBase = truncatedBase.replace(/-+$/, '');
+    }
+
+    return `${truncatedBase}${suffixStr}`;
+  };
+
+  const resolveCandidate = async (
+    candidateSlug: string,
+    suffix: number,
+    attempt: number,
+  ): Promise<string> => {
+    if (attempt >= maxAttempts) {
+      logError(`Slug generation exceeded max attempts for base slug ${baseSlug}`);
+      return candidateSlug;
+    }
+
+    try {
+      const { isValid, validationDecisions } = await validateFieldDetailed(
+        'enterpriseSlug',
+        candidateSlug,
+        adminEmail ? { adminEmail } : undefined,
+        true, // forceValidate to bypass cache
+      );
+
+      // If valid (no error), we found an available slug
+      if (isValid || !validationDecisions?.enterpriseSlug) {
+        return candidateSlug;
+      }
+
+      const { errorCode } = validationDecisions.enterpriseSlug;
+      const isRetryableCollision = errorCode === 'existing_enterprise_customer' || errorCode === 'slug_reserved';
+
+      if (!isRetryableCollision) {
+        logError(`Slug validation returned a non-retryable error for ${candidateSlug}: ${errorCode}`);
+        return candidateSlug;
+      }
+
+      const nextSuffix = suffix + 1;
+      return await resolveCandidate(nextCandidateForSuffix(nextSuffix), nextSuffix, attempt + 1);
+    } catch (error) {
+      logError(`Slug validation failed for ${candidateSlug}`, error);
+      return candidateSlug;
+    }
+  };
+
+  return resolveCandidate(baseSlug, 0, 0);
 };

--- a/src/utils/checkout.ts
+++ b/src/utils/checkout.ts
@@ -170,7 +170,7 @@ export const findAvailableSlug = async (
       const { isValid, validationDecisions } = await validateFieldDetailed(
         'enterpriseSlug',
         candidateSlug,
-        adminEmail ? { adminEmail } : undefined,
+        { adminEmail: adminEmail || '' },
         true, // forceValidate to bypass cache
       );
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-11786

Auto-generate Custom URL slug from Company Name Account details page(Essentials checkout)

In Essentials subscription checkout (Step 2: Account Details), users currently manually enter Company Name + Custom URL slug. We want to auto-generate a suggested slug from Company Name using existing Teams/SSP rules.

Trigger
On blur of the Company Name field (or once Company Name passes required validation), generate and populate the Custom URL slug field.

Slug rules
Lowercase

Replace spaces and any non-alphanumeric characters with a single dash (-)

Collapse multiple dashes

Trim leading/trailing dashes

Allowed characters only: [a-z0-9-]

Max length
30 characters (match existing rule from [ENT-10940](https://2u-internal.atlassian.net/browse/ENT-10940))

Uniqueness / reserved handling
Call the existing backend validation used by the Enterprise Checkout MFE to check slug uniqueness/reservation.

If the slug is taken, append incremental numeric suffix starting at -1, then -2, -3… until an available slug is found.

UI
Show generated slug in the Custom URL field (prefix: <https://enterprise.edx.org/).>

Continue button remains disabled until both fields are valid.




https://github.com/user-attachments/assets/1d61e020-6fde-4d05-8d8e-5f5a72aeed16



[ENT-10940]: https://2u-internal.atlassian.net/browse/ENT-10940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ