### PR TITLE
feat: 11828/Billing details spacing issues and disabling links

### DIFF
--- a/src/components/FormFields/BillingFormFields.tsx
+++ b/src/components/FormFields/BillingFormFields.tsx
@@ -47,7 +47,7 @@ const BillingFormFields = () => {
   };
 
   const paymentElementOptions: StripePaymentElementOptions = {
-    layout: 'tabs', // or 'accordion'
+    layout: 'tabs',
     terms: {
       card: 'never',
     },

--- a/src/components/FormFields/BillingFormFields.tsx
+++ b/src/components/FormFields/BillingFormFields.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { AddressElement, PaymentElement } from '@stripe/react-stripe-js';
-import { StripeAddressElementOptions } from '@stripe/stripe-js';
+import { StripeAddressElementOptions, StripePaymentElementOptions } from '@stripe/stripe-js';
 
 import { FieldContainer } from '@/components/FieldContainer';
 
@@ -45,6 +45,14 @@ const BillingFormFields = () => {
   const addressElementOptions: StripeAddressElementOptions = {
     mode: 'billing',
   };
+
+  const paymentElementOptions: StripePaymentElementOptions = {
+    layout: 'tabs', // or 'accordion'
+    terms: {
+      card: 'never',
+    },
+  };
+
   return (
     <>
       <FieldContainer>
@@ -55,11 +63,11 @@ const BillingFormFields = () => {
       </FieldContainer>
       <FieldContainer>
         <BillingPaymentTitle />
-        <PaymentElement
-          options={{
-            layout: 'tabs', // or 'accordion'
-          }}
-        />
+        <div className="mt-3">
+          <PaymentElement
+            options={paymentElementOptions}
+          />
+        </div>
       </FieldContainer>
     </>
   );

--- a/src/components/FormFields/TermsAndConditionsCheckboxes.tsx
+++ b/src/components/FormFields/TermsAndConditionsCheckboxes.tsx
@@ -182,7 +182,7 @@ const TermsAndConditionsCheckboxes = ({ form }: TermsAndConditionsCheckboxesProp
               defaultMessage="I agree to enroll in a recurring annual subscription for {price}/year USD."
               description="Checkbox label to confirm the recurring subscription with price"
               values={{
-                price: (<DisplayPrice value={yearlySubscriptionCostForQuantity ?? 0} />),
+                price: (<span className="font-weight-bold ml-1"><DisplayPrice value={yearlySubscriptionCostForQuantity ?? 0} /></span>),
               }}
             />
           </Form.Checkbox>

--- a/src/components/PurchaseSummary/EssentialsPurchaseSummary.tsx
+++ b/src/components/PurchaseSummary/EssentialsPurchaseSummary.tsx
@@ -52,7 +52,7 @@ const EssentialsPurchaseSummary = () => {
         totalPerYear={totalPerYear}
         actionButton={<PurchaseSummaryCardButton />}
       />
-      {!isSuccessPage && <div className="mt-3"><ComparePlansBox /></div>}
+      {!isSuccessPage && <div className="mt-4"><ComparePlansBox /></div>}
     </>
   );
 };

--- a/src/components/billing-details-pages/tests/BillingDetailsPage.test.tsx
+++ b/src/components/billing-details-pages/tests/BillingDetailsPage.test.tsx
@@ -37,6 +37,7 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 
 const { sendEnterpriseCheckoutTrackingEvent } = jest.requireMock('@/utils/common');
 const { useCheckoutIntent, useFirstBillableInvoice } = jest.requireMock('@/components/app/data');
+const { PaymentElement } = jest.requireMock('@stripe/react-stripe-js');
 
 jest.mock('@/components/app/data/services/checkout-intent', () => ({
   patchCheckoutIntent: jest.fn(),
@@ -100,6 +101,23 @@ describe('BillingDetailsPage', () => {
     validateText('edX Enterprise Terms');
     validateText('I have read and accepted', { exact: false });
     validateText('I confirm I am subscribing', { exact: false });
+  });
+
+  it('passes terms.card=never to PaymentElement', () => {
+    renderStepperRoute(CheckoutPageRoute.BillingDetails, {
+      config: {},
+      authenticatedUser: {
+        userId: 12345,
+      },
+    } as any);
+
+    expect(PaymentElement).toHaveBeenCalled();
+    const paymentElementProps = (PaymentElement as jest.Mock).mock.calls[0][0];
+    expect(paymentElementProps.options).toEqual(expect.objectContaining({
+      terms: expect.objectContaining({
+        card: 'never',
+      }),
+    }));
   });
 
   it('emits tracking event when subscribe button is clicked', async () => {


### PR DESCRIPTION
[https://2u-internal.atlassian.net/browse/ENT-11828](https://2u-internal.atlassian.net/browse/ENT-11828)

**Changes**

1)Add space between the “By providing your…” sentence and the “Card number” label

2)Remove the “By subscribing, you authorize edX B2B…” sentence since covered in the terms below.

3)Bold the price in the “I agree to enroll…” checkbox.
4) Space fix between Purchase summary and Compare Plan Box(ENT-11826) 
<img width="1885" height="919" alt="image (1)" src="https://github.com/user-attachments/assets/6d7922bd-6054-4705-9d76-86538357e883" />
<img width="1892" height="917" alt="image (2)" src="https://github.com/user-attachments/assets/7bc10448-a9e0-4599-8bdd-5916e3df28a0" />

