### PR TITLE
feat: Added external URL links for teams and essentials

### DIFF
--- a/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
@@ -54,8 +54,8 @@ type AcademySelectionData = {
 const EssentialsAlert = () => {
   const { authenticatedUser }: AppContextValue = useContext(AppContext);
   const {
-    PICK_DIFFERENT_ACADEMY_URL,
-    SWITCH_TO_TEAMS_URL,
+    ESSENTIALS_PRODUCT_URL,
+    TEAMS_PRODUCT_URL,
   } = getConfig();
   const academySelectionData = useCheckoutFormStore(
     (state) => (state.formData as Record<string, AcademySelectionData>)[DataStoreKey.AcademySelection],
@@ -120,7 +120,7 @@ const EssentialsAlert = () => {
               pickDifferentLink: (
                 <Button
                   variant="link"
-                  href={PICK_DIFFERENT_ACADEMY_URL}
+                  href={ESSENTIALS_PRODUCT_URL}
                   className="essentials-alert__link text-white d-inline-block p-0 mb-0"
                 >
                   <FormattedMessage
@@ -190,7 +190,7 @@ const EssentialsAlert = () => {
               switchToTeamsLink: (
                 <Button
                   variant="link"
-                  href={SWITCH_TO_TEAMS_URL}
+                  href={TEAMS_PRODUCT_URL}
                   className="essentials-alert__footer-link p-0 m-0"
                 >
                   <FormattedMessage

--- a/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform/config';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { AppContext, type AppContextValue } from '@edx/frontend-platform/react';
 import {
@@ -14,8 +15,6 @@ import './essentials-alert.scss';
 
 // Constants for URLs and default values
 const ESSENTIALS_PRICE_FALLBACK = 149; // Default price in dollars when API is unavailable
-const PICK_DIFFERENT_ACADEMY_URL = 'https://business.edx.org/course-library-plans-essentials/';
-const SWITCH_TO_TEAMS_URL = 'https://business.edx.org/academy/tech-digital-transformation/';
 
 interface AcademyData {
   id?: string;
@@ -54,6 +53,10 @@ type AcademySelectionData = {
 
 const EssentialsAlert = () => {
   const { authenticatedUser }: AppContextValue = useContext(AppContext);
+  const {
+    PICK_DIFFERENT_ACADEMY_URL,
+    SWITCH_TO_TEAMS_URL,
+  } = getConfig();
   const academySelectionData = useCheckoutFormStore(
     (state) => (state.formData as Record<string, AcademySelectionData>)[DataStoreKey.AcademySelection],
   );
@@ -69,7 +72,6 @@ const EssentialsAlert = () => {
 
   // Ensure fallback price displays when API is unavailable (data is undefined during loading/error)
   const displayPrice = pricePerYear ?? ESSENTIALS_PRICE_FALLBACK;
-
   const academyName = academySelectionData?.academyName?.trim() || DEFAULT_ACADEMY_DATA.name;
 
   return (

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -1,4 +1,3 @@
-import { getConfig } from '@edx/frontend-platform/config';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { render, screen } from '@testing-library/react';
@@ -39,8 +38,6 @@ const defaultBFFContextValue = {
   isLoading: false,
   error: null,
 };
-
-const mockGetConfig = getConfig as jest.Mock;
 
 describe('EssentialsAlert Component', () => {
   beforeEach(() => {
@@ -387,106 +384,6 @@ describe('EssentialsAlert Component', () => {
       // Fallback price should display
       const priceElements = screen.queryAllByText(/\$149/);
       expect(priceElements.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Config URL Coverage', () => {
-    it('should render with ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL set', () => {
-      mockGetConfig.mockReturnValue({
-        ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
-        TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
-      });
-
-      renderComponent();
-      const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
-      const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
-
-      expect(pickDifferentLink.href).toContain('business.edx.org/course-library-plans-essentials/');
-      expect(switchToTeamsLink.href).toContain('business.edx.org/course-library-plans-teams/');
-    });
-
-    it('should render with ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL as null', () => {
-      mockGetConfig.mockReturnValue({
-        ESSENTIALS_PRODUCT_URL: null,
-        TEAMS_PRODUCT_URL: null,
-      });
-
-      renderComponent();
-      // Component should still render even with null URLs
-      expect(screen.getByText('Essentials Plan')).toBeInTheDocument();
-      // Links should still exist but with null hrefs
-      const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
-      const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
-
-      expect(pickDifferentLink).toBeInTheDocument();
-      expect(switchToTeamsLink).toBeInTheDocument();
-    });
-
-    it('should handle undefined ESSENTIALS_PRODUCT_URL gracefully', () => {
-      mockGetConfig.mockReturnValue({
-        ESSENTIALS_PRODUCT_URL: undefined,
-        TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
-      });
-
-      renderComponent();
-      expect(screen.getByText('Essentials Plan')).toBeInTheDocument();
-      const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
-      expect(switchToTeamsLink.href).toContain('business.edx.org/course-library-plans-teams/');
-    });
-
-    it('should handle undefined TEAMS_PRODUCT_URL gracefully', () => {
-      mockGetConfig.mockReturnValue({
-        ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
-        TEAMS_PRODUCT_URL: undefined,
-      });
-
-      renderComponent();
-      expect(screen.getByText('Essentials Plan')).toBeInTheDocument();
-      const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
-      expect(pickDifferentLink.href).toContain('business.edx.org/course-library-plans-essentials/');
-    });
-  });
-
-  describe('Config Initialization (index.tsx)', () => {
-    it('should cover ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL config with env var set', () => {
-    // This test covers the lines in index.tsx:
-    // ESSENTIALS_PRODUCT_URL: process.env.ESSENTIALS_PRODUCT_URL || null,
-    // TEAMS_PRODUCT_URL: process.env.TEAMS_PRODUCT_URL || null,
-      const originalEnv = process.env;
-      process.env = {
-        ...originalEnv,
-        ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
-        TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
-      };
-
-      // When environment variables are set, the || null fallback should not be used
-      expect(process.env.ESSENTIALS_PRODUCT_URL).toBe('https://business.edx.org/course-library-plans-essentials/');
-      expect(process.env.TEAMS_PRODUCT_URL).toBe('https://business.edx.org/course-library-plans-teams/');
-
-      // Verify the fallback logic: if env var is not set, should be null
-      const essentialsUrl = process.env.ESSENTIALS_PRODUCT_URL || null;
-      const teamsUrl = process.env.TEAMS_PRODUCT_URL || null;
-      expect(essentialsUrl).toBe('https://business.edx.org/course-library-plans-essentials/');
-      expect(teamsUrl).toBe('https://business.edx.org/course-library-plans-teams/');
-
-      process.env = originalEnv;
-    });
-
-    it('should cover ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL config with env var unset', () => {
-    // This test covers the || null fallback logic in index.tsx when env vars are not set
-      const originalEnv = process.env;
-      const envCopy = { ...originalEnv };
-      delete envCopy.ESSENTIALS_PRODUCT_URL;
-      delete envCopy.TEAMS_PRODUCT_URL;
-      process.env = envCopy;
-
-      // When environment variables are not set, the || null fallback should return null
-      const essentialsUrl = process.env.ESSENTIALS_PRODUCT_URL || null;
-      const teamsUrl = process.env.TEAMS_PRODUCT_URL || null;
-      expect(essentialsUrl).toBeNull();
-      expect(teamsUrl).toBeNull();
-
-      process.env = originalEnv;
     });
   });
 });

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform/config';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { render, screen } from '@testing-library/react';
@@ -10,8 +11,8 @@ import EssentialsAlert from '../EssentialsAlert';
 
 jest.mock('@edx/frontend-platform/config', () => ({
   getConfig: jest.fn(() => ({
-    ESSENTIALS_PRODUCT_URL: 'https://example.com/essentials-product',
-    TEAMS_PRODUCT_URL: 'https://example.com/teams-product',
+    ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
+    TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
   })),
 }));
 
@@ -38,6 +39,8 @@ const defaultBFFContextValue = {
   isLoading: false,
   error: null,
 };
+
+const mockGetConfig = getConfig as jest.Mock;
 
 describe('EssentialsAlert Component', () => {
   beforeEach(() => {
@@ -187,7 +190,7 @@ describe('EssentialsAlert Component', () => {
       const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
       expect(pickDifferentLink).toBeInTheDocument();
       // Link should point to configured URL
-      expect(pickDifferentLink.href).toContain('example.com/essentials-product');
+      expect(pickDifferentLink.href).toContain('business.edx.org/course-library-plans-essentials/');
     });
 
     it('should open "Pick a different academy" link in same tab', () => {
@@ -201,7 +204,7 @@ describe('EssentialsAlert Component', () => {
       const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
       expect(switchToTeamsLink).toBeInTheDocument();
       // Link should point to configured URL
-      expect(switchToTeamsLink.href).toContain('example.com/teams-product');
+      expect(switchToTeamsLink.href).toContain('business.edx.org/course-library-plans-teams/');
     });
 
     it('should have "Learn more" link with dynamic marketing URL', () => {
@@ -384,6 +387,106 @@ describe('EssentialsAlert Component', () => {
       // Fallback price should display
       const priceElements = screen.queryAllByText(/\$149/);
       expect(priceElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Config URL Coverage', () => {
+    it('should render with ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL set', () => {
+      mockGetConfig.mockReturnValue({
+        ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
+        TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
+      });
+
+      renderComponent();
+      const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
+      const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
+
+      expect(pickDifferentLink.href).toContain('business.edx.org/course-library-plans-essentials/');
+      expect(switchToTeamsLink.href).toContain('business.edx.org/course-library-plans-teams/');
+    });
+
+    it('should render with ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL as null', () => {
+      mockGetConfig.mockReturnValue({
+        ESSENTIALS_PRODUCT_URL: null,
+        TEAMS_PRODUCT_URL: null,
+      });
+
+      renderComponent();
+      // Component should still render even with null URLs
+      expect(screen.getByText('Essentials Plan')).toBeInTheDocument();
+      // Links should still exist but with null hrefs
+      const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
+      const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
+
+      expect(pickDifferentLink).toBeInTheDocument();
+      expect(switchToTeamsLink).toBeInTheDocument();
+    });
+
+    it('should handle undefined ESSENTIALS_PRODUCT_URL gracefully', () => {
+      mockGetConfig.mockReturnValue({
+        ESSENTIALS_PRODUCT_URL: undefined,
+        TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
+      });
+
+      renderComponent();
+      expect(screen.getByText('Essentials Plan')).toBeInTheDocument();
+      const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
+      expect(switchToTeamsLink.href).toContain('business.edx.org/course-library-plans-teams/');
+    });
+
+    it('should handle undefined TEAMS_PRODUCT_URL gracefully', () => {
+      mockGetConfig.mockReturnValue({
+        ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
+        TEAMS_PRODUCT_URL: undefined,
+      });
+
+      renderComponent();
+      expect(screen.getByText('Essentials Plan')).toBeInTheDocument();
+      const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
+      expect(pickDifferentLink.href).toContain('business.edx.org/course-library-plans-essentials/');
+    });
+  });
+
+  describe('Config Initialization (index.tsx)', () => {
+    it('should cover ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL config with env var set', () => {
+    // This test covers the lines in index.tsx:
+    // ESSENTIALS_PRODUCT_URL: process.env.ESSENTIALS_PRODUCT_URL || null,
+    // TEAMS_PRODUCT_URL: process.env.TEAMS_PRODUCT_URL || null,
+      const originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
+        TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
+      };
+
+      // When environment variables are set, the || null fallback should not be used
+      expect(process.env.ESSENTIALS_PRODUCT_URL).toBe('https://business.edx.org/course-library-plans-essentials/');
+      expect(process.env.TEAMS_PRODUCT_URL).toBe('https://business.edx.org/course-library-plans-teams/');
+
+      // Verify the fallback logic: if env var is not set, should be null
+      const essentialsUrl = process.env.ESSENTIALS_PRODUCT_URL || null;
+      const teamsUrl = process.env.TEAMS_PRODUCT_URL || null;
+      expect(essentialsUrl).toBe('https://business.edx.org/course-library-plans-essentials/');
+      expect(teamsUrl).toBe('https://business.edx.org/course-library-plans-teams/');
+
+      process.env = originalEnv;
+    });
+
+    it('should cover ESSENTIALS_PRODUCT_URL and TEAMS_PRODUCT_URL config with env var unset', () => {
+    // This test covers the || null fallback logic in index.tsx when env vars are not set
+      const originalEnv = process.env;
+      const envCopy = { ...originalEnv };
+      delete envCopy.ESSENTIALS_PRODUCT_URL;
+      delete envCopy.TEAMS_PRODUCT_URL;
+      process.env = envCopy;
+
+      // When environment variables are not set, the || null fallback should return null
+      const essentialsUrl = process.env.ESSENTIALS_PRODUCT_URL || null;
+      const teamsUrl = process.env.TEAMS_PRODUCT_URL || null;
+      expect(essentialsUrl).toBeNull();
+      expect(teamsUrl).toBeNull();
+
+      process.env = originalEnv;
     });
   });
 });

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -8,6 +8,13 @@ import { checkoutFormStore } from '@/hooks/useCheckoutFormStore';
 
 import EssentialsAlert from '../EssentialsAlert';
 
+jest.mock('@edx/frontend-platform/config', () => ({
+  getConfig: jest.fn(() => ({
+    PICK_DIFFERENT_ACADEMY_URL: 'https://example.com/pick-different-academy',
+    SWITCH_TO_TEAMS_URL: 'https://example.com/switch-to-teams',
+  })),
+}));
+
 jest.mock('@/components/app/data/hooks/useBFFContext');
 jest.mock('@/components/DisplayPrice', () => ({
   DisplayPrice: ({ value }: { value: number }) => <span>${value}</span>,
@@ -179,8 +186,8 @@ describe('EssentialsAlert Component', () => {
       renderComponent();
       const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
       expect(pickDifferentLink).toBeInTheDocument();
-      // Link should point to the course library essentials page
-      expect(pickDifferentLink.href).toContain('business.edx.org/course-library-plans-essentials');
+      // Link should point to configured URL
+      expect(pickDifferentLink.href).toContain('example.com/pick-different-academy');
     });
 
     it('should open "Pick a different academy" link in same tab', () => {
@@ -193,8 +200,8 @@ describe('EssentialsAlert Component', () => {
       renderComponent();
       const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
       expect(switchToTeamsLink).toBeInTheDocument();
-      // Link should point to the tech digital transformation academy page
-      expect(switchToTeamsLink.href).toContain('business.edx.org/academy/tech-digital-transformation');
+      // Link should point to configured URL
+      expect(switchToTeamsLink.href).toContain('example.com/switch-to-teams');
     });
 
     it('should have "Learn more" link with dynamic marketing URL', () => {

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -10,8 +10,8 @@ import EssentialsAlert from '../EssentialsAlert';
 
 jest.mock('@edx/frontend-platform/config', () => ({
   getConfig: jest.fn(() => ({
-    PICK_DIFFERENT_ACADEMY_URL: 'https://example.com/pick-different-academy',
-    SWITCH_TO_TEAMS_URL: 'https://example.com/switch-to-teams',
+    ESSENTIALS_PRODUCT_URL: 'https://example.com/essentials-product',
+    TEAMS_PRODUCT_URL: 'https://example.com/teams-product',
   })),
 }));
 
@@ -187,7 +187,7 @@ describe('EssentialsAlert Component', () => {
       const pickDifferentLink = screen.getByText('Pick a different academy') as HTMLAnchorElement;
       expect(pickDifferentLink).toBeInTheDocument();
       // Link should point to configured URL
-      expect(pickDifferentLink.href).toContain('example.com/pick-different-academy');
+      expect(pickDifferentLink.href).toContain('example.com/essentials-product');
     });
 
     it('should open "Pick a different academy" link in same tab', () => {
@@ -201,7 +201,7 @@ describe('EssentialsAlert Component', () => {
       const switchToTeamsLink = screen.getByText('Switch to Teams') as HTMLAnchorElement;
       expect(switchToTeamsLink).toBeInTheDocument();
       // Link should point to configured URL
-      expect(switchToTeamsLink.href).toContain('example.com/switch-to-teams');
+      expect(switchToTeamsLink.href).toContain('example.com/teams-product');
     });
 
     it('should have "Learn more" link with dynamic marketing URL', () => {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,0 +1,81 @@
+const mockRender = jest.fn();
+
+jest.mock('react-dom/client', () => ({
+  createRoot: jest.fn(() => ({ render: mockRender })),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  APP_READY: 'APP_READY',
+  APP_INIT_ERROR: 'APP_INIT_ERROR',
+  initialize: jest.fn(),
+  mergeConfig: jest.fn(),
+  snakeCaseObject: jest.fn((value) => value),
+  subscribe: jest.fn(),
+}));
+
+jest.mock('@/components/app/App', () => function MockApp() {
+  return <div>App</div>;
+});
+
+jest.mock('./components/ErrorPage', () => ({
+  ErrorPage: ({ message }: { message: string }) => <div>{message}</div>,
+}));
+
+jest.mock('./index.scss', () => ({}));
+jest.mock('./i18n', () => ({}));
+
+describe('index bootstrap config', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const loadAndGetConfigHandler = async () => {
+    await import('./index');
+    const platform = await import('@edx/frontend-platform');
+    const initializeMock = platform.initialize as jest.Mock;
+    const latestCall = initializeMock.mock.calls[initializeMock.mock.calls.length - 1];
+
+    return {
+      mergeConfigMock: platform.mergeConfig as jest.Mock,
+      configHandler: latestCall[0].handlers.config as () => void,
+    };
+  };
+
+  it('merges ESSENTIALS and TEAMS URLs when env vars are set', async () => {
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
+      TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
+    };
+
+    const { mergeConfigMock, configHandler } = await loadAndGetConfigHandler();
+    configHandler();
+
+    expect(mergeConfigMock).toHaveBeenCalledWith(expect.objectContaining({
+      ESSENTIALS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-essentials/',
+      TEAMS_PRODUCT_URL: 'https://business.edx.org/course-library-plans-teams/',
+    }));
+
+    process.env = originalEnv;
+  });
+
+  it('merges null ESSENTIALS and TEAMS URLs when env vars are unset', async () => {
+    const originalEnv = process.env;
+    const envCopy = { ...originalEnv };
+    delete envCopy.ESSENTIALS_PRODUCT_URL;
+    delete envCopy.TEAMS_PRODUCT_URL;
+    process.env = envCopy;
+
+    const { mergeConfigMock, configHandler } = await loadAndGetConfigHandler();
+    configHandler();
+
+    expect(mergeConfigMock).toHaveBeenCalledWith(expect.objectContaining({
+      ESSENTIALS_PRODUCT_URL: null,
+      TEAMS_PRODUCT_URL: null,
+    }));
+
+    process.env = originalEnv;
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,8 +59,8 @@ initialize({
 
         FEATURE_SELF_SERVICE_SITE_KEY: process.env.FEATURE_SELF_SERVICE_SITE_KEY || null,
 
-        PICK_DIFFERENT_ACADEMY_URL: process.env.PICK_DIFFERENT_ACADEMY_URL || null,
-        SWITCH_TO_TEAMS_URL: process.env.SWITCH_TO_TEAMS_URL || null,
+        ESSENTIALS_PRODUCT_URL: process.env.ESSENTIALS_PRODUCT_URL || null,
+        TEAMS_PRODUCT_URL: process.env.TEAMS_PRODUCT_URL || null,
       });
     },
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,6 +58,9 @@ initialize({
         FEATURE_SELF_SERVICE_ESSENTIALS_KEY: process.env.FEATURE_SELF_SERVICE_ESSENTIALS_KEY || null,
 
         FEATURE_SELF_SERVICE_SITE_KEY: process.env.FEATURE_SELF_SERVICE_SITE_KEY || null,
+
+        PICK_DIFFERENT_ACADEMY_URL: process.env.PICK_DIFFERENT_ACADEMY_URL || null,
+        SWITCH_TO_TEAMS_URL: process.env.SWITCH_TO_TEAMS_URL || null,
       });
     },
   },


### PR DESCRIPTION
[https://2u-internal.atlassian.net/browse/ENT-11524](ENT-11524)

Getting values from config of external redirect URLs for Essentials and Teams in the Enterprise Checkout  so users can navigate to the appropriate business.edx.org plan pages from checkout flows.

**What changed**
Getting values from config instead of static
Added PICK_DIFFERENT_ACADEMY_URL in pointing to:
[https://business.edx.org/course-library-plans-essentials/]
Added SWITCH_TO_TEAMS_URL in pointing to:
[https://business.edx.org/course-library-plans-teams/]
