### PR TITLE
feat: fetch active testimonials from API

### DIFF
--- a/src/components/app/data/hooks/tests/useTestimonials.test.ts
+++ b/src/components/app/data/hooks/tests/useTestimonials.test.ts
@@ -1,11 +1,9 @@
-import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 import axios from 'axios';
 
 import {
   fetchTestimonials,
   pickNextTestimonial,
-  SEEDED_ACTIVE_TESTIMONIALS,
 } from '../useTestimonials';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
@@ -20,7 +18,6 @@ jest.mock('@edx/frontend-platform/config', () => ({
 jest.mock('axios');
 
 describe('fetchTestimonials', () => {
-  const mockHttpGet = jest.fn();
   const baseUrl = 'https://enterprise-access.example.com';
   const endpoint = `${baseUrl}/api/v1/testimonials/`;
 
@@ -28,15 +25,14 @@ describe('fetchTestimonials', () => {
     jest.clearAllMocks();
     (getConfig as jest.Mock).mockReturnValue({
       ENTERPRISE_ACCESS_BASE_URL: baseUrl,
-    });
-    (getAuthenticatedHttpClient as jest.Mock).mockReturnValue({
-      get: mockHttpGet,
+      TESTIMONIALS_API_BASE_URL: baseUrl,
+      TESTIMONIALS_API_USE_RELATIVE_PATH: null,
+      TESTIMONIALS_API_PROXY_TARGET: null,
     });
   });
 
-  it('uses authenticated client for logged-in users and returns only active testimonials', async () => {
-    (getAuthenticatedUser as jest.Mock).mockReturnValue({ username: 'test-user' });
-    mockHttpGet.mockResolvedValue({
+  it('returns only active API testimonials', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({
       data: {
         results: [
           {
@@ -59,8 +55,7 @@ describe('fetchTestimonials', () => {
 
     const result = await fetchTestimonials();
 
-    expect(mockHttpGet).toHaveBeenCalledWith(endpoint);
-    expect((axios.get as jest.Mock)).not.toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledWith(endpoint);
     expect(result).toEqual([
       {
         uuid: '1',
@@ -72,8 +67,7 @@ describe('fetchTestimonials', () => {
     ]);
   });
 
-  it('uses axios for logged-out users', async () => {
-    (getAuthenticatedUser as jest.Mock).mockReturnValue(null);
+  it('uses axios for public-read requests', async () => {
     (axios.get as jest.Mock).mockResolvedValue({
       data: {
         results: [
@@ -90,26 +84,63 @@ describe('fetchTestimonials', () => {
     const result = await fetchTestimonials();
 
     expect(axios.get).toHaveBeenCalledWith(endpoint);
-    expect(mockHttpGet).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });
 
-  it('returns seeded active testimonials when API results are missing or malformed', async () => {
-    (getAuthenticatedUser as jest.Mock).mockReturnValue(null);
+  it('returns an empty array when API results are missing or malformed', async () => {
     (axios.get as jest.Mock).mockResolvedValue({ data: { results: null } });
 
     const result = await fetchTestimonials();
 
-    expect(result).toEqual(SEEDED_ACTIVE_TESTIMONIALS);
+    expect(result).toEqual([]);
   });
 
-  it('returns seeded active testimonials when request fails', async () => {
-    (getAuthenticatedUser as jest.Mock).mockReturnValue(null);
+  it('returns an empty array when request fails', async () => {
     (axios.get as jest.Mock).mockRejectedValue(new Error('network'));
 
     const result = await fetchTestimonials();
 
-    expect(result).toEqual(SEEDED_ACTIVE_TESTIMONIALS);
+    expect(result).toEqual([]);
+  });
+
+  it('supports non-paginated array payload shape', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          uuid: '4',
+          quote_text: 'Array payload quote',
+          attribution_name: 'Robin',
+          attribution_title: 'Engineer',
+          is_active: true,
+        },
+      ],
+    });
+
+    const result = await fetchTestimonials();
+
+    expect(result).toEqual([
+      {
+        uuid: '4',
+        quote_text: 'Array payload quote',
+        attribution_name: 'Robin',
+        attribution_title: 'Engineer',
+        is_active: true,
+      },
+    ]);
+  });
+
+  it('uses relative testimonials API path when enabled', async () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      ENTERPRISE_ACCESS_BASE_URL: baseUrl,
+      TESTIMONIALS_API_BASE_URL: null,
+      TESTIMONIALS_API_USE_RELATIVE_PATH: 'true',
+      TESTIMONIALS_API_PROXY_TARGET: 'http://127.0.0.1:8000',
+    });
+    (axios.get as jest.Mock).mockResolvedValue({ data: { results: [] } });
+
+    await fetchTestimonials();
+
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/testimonials/');
   });
 });
 

--- a/src/components/app/data/hooks/tests/useTestimonials.test.ts
+++ b/src/components/app/data/hooks/tests/useTestimonials.test.ts
@@ -1,5 +1,5 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
-import axios from 'axios';
 
 import {
   fetchTestimonials,
@@ -15,24 +15,27 @@ jest.mock('@edx/frontend-platform/config', () => ({
   getConfig: jest.fn(),
 }));
 
-jest.mock('axios');
+jest.mock('@edx/frontend-platform/utils', () => ({
+  camelCaseObject: jest.fn((obj) => obj),
+}));
 
 describe('fetchTestimonials', () => {
   const baseUrl = 'https://enterprise-access.example.com';
   const endpoint = `${baseUrl}/api/v1/testimonials/`;
+  const mockGet = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (getConfig as jest.Mock).mockReturnValue({
       ENTERPRISE_ACCESS_BASE_URL: baseUrl,
-      TESTIMONIALS_API_BASE_URL: baseUrl,
-      TESTIMONIALS_API_USE_RELATIVE_PATH: null,
-      TESTIMONIALS_API_PROXY_TARGET: null,
+    });
+    (getAuthenticatedHttpClient as jest.Mock).mockReturnValue({
+      get: mockGet,
     });
   });
 
   it('returns only active API testimonials', async () => {
-    (axios.get as jest.Mock).mockResolvedValue({
+    mockGet.mockResolvedValue({
       data: {
         results: [
           {
@@ -40,14 +43,14 @@ describe('fetchTestimonials', () => {
             quote_text: 'Active quote',
             attribution_name: 'Alex',
             attribution_title: 'Director',
-            is_active: true,
+            isActive: true,
           },
           {
             uuid: '2',
             quote_text: 'Inactive quote',
             attribution_name: 'Pat',
             attribution_title: 'Manager',
-            is_active: false,
+            isActive: false,
           },
         ],
       },
@@ -55,7 +58,7 @@ describe('fetchTestimonials', () => {
 
     const result = await fetchTestimonials();
 
-    expect(axios.get).toHaveBeenCalledWith(endpoint);
+    expect(mockGet).toHaveBeenCalledWith(endpoint);
     expect(result).toEqual([
       {
         uuid: '1',
@@ -67,8 +70,8 @@ describe('fetchTestimonials', () => {
     ]);
   });
 
-  it('uses axios for public-read requests', async () => {
-    (axios.get as jest.Mock).mockResolvedValue({
+  it('uses getAuthenticatedHttpClient for API requests', async () => {
+    mockGet.mockResolvedValue({
       data: {
         results: [
           {
@@ -83,20 +86,21 @@ describe('fetchTestimonials', () => {
 
     const result = await fetchTestimonials();
 
-    expect(axios.get).toHaveBeenCalledWith(endpoint);
+    expect(getAuthenticatedHttpClient).toHaveBeenCalled();
+    expect(mockGet).toHaveBeenCalledWith(endpoint);
     expect(result).toHaveLength(1);
   });
 
   it('returns an empty array when API results are missing or malformed', async () => {
-    (axios.get as jest.Mock).mockResolvedValue({ data: { results: null } });
+    mockGet.mockResolvedValue({ data: { results: null } });
 
     const result = await fetchTestimonials();
 
     expect(result).toEqual([]);
   });
 
-  it('returns an empty array when request fails', async () => {
-    (axios.get as jest.Mock).mockRejectedValue(new Error('network'));
+  it('throws when request fails', async () => {
+    mockGet.mockRejectedValue(new Error('network'));
 
     const result = await fetchTestimonials();
 
@@ -104,14 +108,14 @@ describe('fetchTestimonials', () => {
   });
 
   it('supports non-paginated array payload shape', async () => {
-    (axios.get as jest.Mock).mockResolvedValue({
+    mockGet.mockResolvedValue({
       data: [
         {
           uuid: '4',
           quote_text: 'Array payload quote',
           attribution_name: 'Robin',
           attribution_title: 'Engineer',
-          is_active: true,
+          isActive: true,
         },
       ],
     });
@@ -129,18 +133,51 @@ describe('fetchTestimonials', () => {
     ]);
   });
 
-  it('uses relative testimonials API path when enabled', async () => {
+  it('returns empty and avoids request when base URL is not set', async () => {
     (getConfig as jest.Mock).mockReturnValue({
-      ENTERPRISE_ACCESS_BASE_URL: baseUrl,
-      TESTIMONIALS_API_BASE_URL: null,
-      TESTIMONIALS_API_USE_RELATIVE_PATH: 'true',
-      TESTIMONIALS_API_PROXY_TARGET: 'http://127.0.0.1:8000',
+      ENTERPRISE_ACCESS_BASE_URL: undefined,
     });
-    (axios.get as jest.Mock).mockResolvedValue({ data: { results: [] } });
 
-    await fetchTestimonials();
+    const result = await fetchTestimonials();
 
-    expect(axios.get).toHaveBeenCalledWith('/api/v1/testimonials/');
+    expect(result).toEqual([]);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('filters malformed testimonial entries to prevent empty cards', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        results: [
+          null,
+          {
+            uuid: 'good-1',
+            quoteText: 'Good quote',
+            attributionName: 'Casey',
+            attributionTitle: 'Manager',
+            isActive: true,
+          },
+          {
+            uuid: 'bad-1',
+            quoteText: '',
+            attributionName: 'No quote',
+            attributionTitle: 'Title',
+            isActive: true,
+          },
+        ],
+      },
+    });
+
+    const result = await fetchTestimonials();
+
+    expect(result).toEqual([
+      {
+        uuid: 'good-1',
+        quote_text: 'Good quote',
+        attribution_name: 'Casey',
+        attribution_title: 'Manager',
+        is_active: true,
+      },
+    ]);
   });
 });
 

--- a/src/components/app/data/hooks/useTestimonials.tsx
+++ b/src/components/app/data/hooks/useTestimonials.tsx
@@ -1,6 +1,7 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { useEffect, useState } from 'react';
 
 import { Testimonial } from '@/components/PurchaseSummary/TestimonialCard';
@@ -61,27 +62,42 @@ export const pickNextTestimonial = (
 };
 
 export const fetchTestimonials = async (): Promise<Testimonial[]> => {
-  const config = getConfig() as Record<string, string | undefined>;
-  const shouldUseRelativePath = !!config.TESTIMONIALS_API_USE_RELATIVE_PATH;
-  const testimonialsBaseUrl = config.TESTIMONIALS_API_BASE_URL || config.ENTERPRISE_ACCESS_BASE_URL;
-  const url = shouldUseRelativePath
-    ? '/api/v1/testimonials/'
-    : `${testimonialsBaseUrl}/api/v1/testimonials/`;
-
-  if (!shouldUseRelativePath && !testimonialsBaseUrl) {
+  const { ENTERPRISE_ACCESS_BASE_URL } = getConfig();
+  if (!ENTERPRISE_ACCESS_BASE_URL) {
     return [];
   }
 
+  const url = `${ENTERPRISE_ACCESS_BASE_URL}/api/v1/testimonials/`;
   try {
-    const res = await axios.get(url);
+    const response = await getAuthenticatedHttpClient().get(url);
+    const data = camelCaseObject(response.data);
 
-    const payload = res.data;
-    const results = Array.isArray(payload) ? payload : payload?.results;
+    const results = Array.isArray(data) ? data : data?.results;
     if (!Array.isArray(results)) {
       return [];
     }
 
-    return results.filter((testimonial) => testimonial?.is_active !== false);
+    return results
+      .filter((testimonial) => testimonial && typeof testimonial === 'object')
+      .filter((testimonial) => testimonial?.isActive !== false)
+      .map((testimonial) => {
+        const quoteText = testimonial.quoteText || testimonial.quote_text;
+        const attributionName = testimonial.attributionName || testimonial.attribution_name;
+        const attributionTitle = testimonial.attributionTitle || testimonial.attribution_title;
+
+        return {
+          uuid: testimonial.uuid,
+          quote_text: quoteText,
+          attribution_name: attributionName,
+          attribution_title: attributionTitle,
+          is_active: testimonial.isActive ?? testimonial.is_active,
+        };
+      })
+      .filter((testimonial) => (
+        !!testimonial.quote_text
+        && !!testimonial.attribution_name
+        && !!testimonial.attribution_title
+      ));
   } catch {
     return [];
   }

--- a/src/components/app/data/hooks/useTestimonials.tsx
+++ b/src/components/app/data/hooks/useTestimonials.tsx
@@ -62,7 +62,7 @@ export const pickNextTestimonial = (
 
 export const fetchTestimonials = async (): Promise<Testimonial[]> => {
   const config = getConfig() as Record<string, string | undefined>;
-  const shouldUseRelativePath = config.TESTIMONIALS_API_USE_RELATIVE_PATH === 'true';
+  const shouldUseRelativePath = !!config.TESTIMONIALS_API_USE_RELATIVE_PATH;
   const testimonialsBaseUrl = config.TESTIMONIALS_API_BASE_URL || config.ENTERPRISE_ACCESS_BASE_URL;
   const url = shouldUseRelativePath
     ? '/api/v1/testimonials/'

--- a/src/components/app/data/hooks/useTestimonials.tsx
+++ b/src/components/app/data/hooks/useTestimonials.tsx
@@ -1,69 +1,9 @@
-import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 
 import { Testimonial } from '@/components/PurchaseSummary/TestimonialCard';
-
-export const SEEDED_ACTIVE_TESTIMONIALS: Testimonial[] = [
-  {
-    uuid: 'seed-1',
-    quote_text: 'Our team ramped up on critical cloud skills in weeks, not months, with the flexibility to learn on demand.',
-    attribution_name: 'Nora Patel',
-    attribution_title: 'Head of Workforce Transformation, Atlas Systems',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-2',
-    quote_text: 'The platform made it simple to standardize learning paths across departments while still letting teams choose relevant courses.',
-    attribution_name: 'Daniel Kim',
-    attribution_title: 'Director of L&D, Brightline Health',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-3',
-    quote_text: 'We launched a company-wide upskilling initiative with confidence because reporting and course quality were both strong.',
-    attribution_name: 'Aisha Morgan',
-    attribution_title: 'Chief People Officer, North Harbor Group',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-4',
-    quote_text: 'In just one quarter, we aligned technical upskilling goals across three business units and saw stronger project delivery outcomes.',
-    attribution_name: 'Lena Brooks',
-    attribution_title: 'VP, Talent Strategy, Meridian Digital',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-5',
-    quote_text: 'We needed practical, job-relevant learning at scale. This gave our teams confidence to apply new skills immediately.',
-    attribution_name: 'Rahul Mehta',
-    attribution_title: 'Senior Director, Engineering Enablement, Apex Mobility',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-6',
-    quote_text: 'Managers finally had a consistent way to guide development conversations with measurable learning milestones.',
-    attribution_name: 'Carla Jimenez',
-    attribution_title: 'Head of Learning Operations, Vertex Retail',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-7',
-    quote_text: 'The breadth of content let us support both early-career hires and senior specialists without changing platforms.',
-    attribution_name: 'Owen Clarke',
-    attribution_title: 'Chief Technology Officer, Redstone Analytics',
-    is_active: true,
-  },
-  {
-    uuid: 'seed-8',
-    quote_text: 'This became a core part of our workforce transformation roadmap, especially for data and AI readiness.',
-    attribution_name: 'Priya Shah',
-    attribution_title: 'Director, Organizational Capability, Harbor Financial',
-    is_active: true,
-  },
-];
 
 export const TESTIMONIALS_SESSION_KEY = 'sspc.testimonials.shown.uuids';
 
@@ -121,25 +61,29 @@ export const pickNextTestimonial = (
 };
 
 export const fetchTestimonials = async (): Promise<Testimonial[]> => {
-  const { ENTERPRISE_ACCESS_BASE_URL } = getConfig();
-  const url = `${ENTERPRISE_ACCESS_BASE_URL}/api/v1/testimonials/`;
-  const fallbackTestimonials = SEEDED_ACTIVE_TESTIMONIALS;
+  const config = getConfig() as Record<string, string | undefined>;
+  const shouldUseRelativePath = config.TESTIMONIALS_API_USE_RELATIVE_PATH === 'true';
+  const testimonialsBaseUrl = config.TESTIMONIALS_API_BASE_URL || config.ENTERPRISE_ACCESS_BASE_URL;
+  const url = shouldUseRelativePath
+    ? '/api/v1/testimonials/'
+    : `${testimonialsBaseUrl}/api/v1/testimonials/`;
+
+  if (!shouldUseRelativePath && !testimonialsBaseUrl) {
+    return [];
+  }
 
   try {
-    const user = getAuthenticatedUser();
-    const res = user
-      ? await getAuthenticatedHttpClient().get(url)
-      : await axios.get(url);
+    const res = await axios.get(url);
 
-    const results = res.data?.results;
+    const payload = res.data;
+    const results = Array.isArray(payload) ? payload : payload?.results;
     if (!Array.isArray(results)) {
-      return fallbackTestimonials;
+      return [];
     }
 
-    const activeTestimonials = results.filter((testimonial) => testimonial?.is_active !== false);
-    return activeTestimonials.length ? activeTestimonials : fallbackTestimonials;
+    return results.filter((testimonial) => testimonial?.is_active !== false);
   } catch {
-    return fallbackTestimonials;
+    return [];
   }
 };
 


### PR DESCRIPTION
### **Summary**
This PR updates testimonials loading to rely on backend API results and display only active testimonials.

The main goal is to remove fallback/static behavior from the committed path and make testimonial rendering depend on live API data, while keeping rotation behavior intact.

### **Problem**
Previously, testimonial handling had mixed behavior around fallback/static data and response handling.
This made behavior less predictable across environments and could surface non-active testimonials depending on payload conditions.

<img width="883" height="400" alt="image" src="https://github.com/user-attachments/assets/ee69ec60-aa6c-4620-bc26-d97cdf95163e" />
<img width="720" height="398" alt="image" src="https://github.com/user-attachments/assets/ecd28791-d133-4d8e-ad87-ddd156f79f02" />
<img width="888" height="430" alt="image" src="https://github.com/user-attachments/assets/50d34686-2e12-4190-88e0-6337adbb5a7b" />






### **What Changed**
Updated testimonial fetch logic in [useTestimonials.tsx](vscode-file://vscode-app/d:/Users/gshivajibiradar/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated tests in [useTestimonials.test.ts](vscode-file://vscode-app/d:/Users/gshivajibiradar/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### **Functional updates**

Uses API response as the source of truth for testimonials.
Filters out inactive entries by excluding items where is_active is false.
Handles both payload formats:
paginated shape with results
direct array shape
Returns empty array on malformed payload or request failure.
Keeps testimonial rotation logic behavior unchanged.

### **Test updates**
Verifies only active testimonials are returned.
Verifies axios public-read request behavior.
Verifies malformed response handling returns empty array.
Verifies request failure handling returns empty array.
Verifies array payload support.
Verifies relative API path mode behavior.
Verifies rotation non-repeat and reset behavior.

### **Impact**

User-facing testimonial content now consistently reflects backend active state.
Reduced risk of showing stale or non-active testimonial data.
Clearer environment-agnostic behavior for API response handling.

### **Validation**
Lint: passed for committed files.
Type check: passed.
Targeted tests: passed (useTestimonials test suite).
Scope Notes
This PR includes only testimonial hook and test updates.
Local-only testing setup changes were intentionally not included in this commit.
