### PR TITLE
feat: Added rounded corners

### DIFF
--- a/src/components/FieldContainer/FieldContainer.tsx
+++ b/src/components/FieldContainer/FieldContainer.tsx
@@ -6,7 +6,7 @@ interface FieldContainerProps {
 }
 
 const FieldContainer = ({ children }: FieldContainerProps) => (
-  <Stack spacing={2} className="bg-light-300 p-4.5 rounded">
+  <Stack spacing={2} className="bg-light-300 p-4.5 ssp-box">
     {children}
   </Stack>
 );

--- a/src/components/PurchaseSummary/ComparePlansBox.tsx
+++ b/src/components/PurchaseSummary/ComparePlansBox.tsx
@@ -23,7 +23,7 @@ const ComparePlansBox = () => {
   );
 
   return (
-    <Card className="bg-light-300 rounded border border-light-400 p-4.5" style={{ width: 'min(100%, 401px)', minHeight: '120px' }}>
+    <Card className="bg-light-300 ssp-box border border-light-400 p-4.5" style={{ width: 'min(100%, 401px)', minHeight: '120px' }}>
       <Card.Body className="p-0">
         <p className="mb-0">
           <FormattedMessage

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,8 +8,7 @@
 
 @import "/src/styles/nprogress.scss";
 
-/* Apply card/alert radius to root so Paragon card and alert components pick it up.
-   Also set button radius variables explicitly so buttons keep Paragon defaults. */
+/* Apply card/alert radius to root so Paragon card and alert components pick it up.*/
 :root {
   --pgn-size-card-border-radius-base: 16px;
   --pgn-size-alert-border-radius: 16px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,6 +8,21 @@
 
 @import "/src/styles/nprogress.scss";
 
+/* Apply card/alert radius to root so Paragon card and alert components pick it up.
+   Also set button radius variables explicitly so buttons keep Paragon defaults. */
+:root {
+  --pgn-size-card-border-radius-base: 16px;
+  --pgn-size-alert-border-radius: 16px;
+  --pgn-size-btn-border-radius-base: 0.375rem;
+  --pgn-size-btn-border-radius-sm: 0.25rem;
+  --pgn-size-btn-border-radius-lg: 0.425rem;
+}
+
+/* Boxes that should follow card radius (FieldContainer and similar) */
+.ssp-box {
+  border-radius: var(--pgn-size-card-border-radius-base, 16px);
+}
+
 #layout {
   display: flex;
   flex-direction: column;

--- a/src/index.scss
+++ b/src/index.scss
@@ -13,9 +13,6 @@
 :root {
   --pgn-size-card-border-radius-base: 16px;
   --pgn-size-alert-border-radius: 16px;
-  --pgn-size-btn-border-radius-base: 0.375rem;
-  --pgn-size-btn-border-radius-sm: 0.25rem;
-  --pgn-size-btn-border-radius-lg: 0.425rem;
 }
 
 /* Boxes that should follow card radius (FieldContainer and similar) */


### PR DESCRIPTION
**Jira :**  [https://2u-internal.atlassian.net/browse/ENT-11895](url)

**Description :**
**What changed**
Updated the border-radius value on the following components to be consistent with the rust-colored Essentials Plan panel:
- "Number of licenses" input box
- "Purchase summary" sidebar box
- "Not sure which plan is right for you? Compare plans." box
- Any other card/container elements with a mismatched border-radius

**Pages affected:**
Plan Details
Account Details
Billing Details

Why
The border-radius was inconsistent across UI containers on the checkout pages — some boxes had sharper corners while the rust-colored panel used a more rounded style. This PR brings visual consistency to the entire checkout flow.

<img width="1035" height="466" alt="image" src="https://github.com/user-attachments/assets/47235847-3d27-4611-b2f4-24495d1cda82" />


