### PR TITLE
feat: render tags info in alert

### DIFF
--- a/src/components/plan-details-pages/EssentialsAlert/AcademyTags.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/AcademyTags.tsx
@@ -1,0 +1,24 @@
+interface AcademyTag {
+  id: number;
+  title: string;
+}
+
+interface AcademyTagsProps {
+  tags: readonly AcademyTag[];
+}
+
+const AcademyTags = ({ tags }: AcademyTagsProps) => {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="essentials-alert__tags">
+      {tags.map(({ id, title }) => (
+        <li key={id} className="essentials-alert__tag">{title}</li>
+      ))}
+    </ul>
+  );
+};
+
+export default AcademyTags;

--- a/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
@@ -117,6 +117,8 @@ const EssentialsAlert = () => {
               <Button
                 variant="link"
                 href={academyMarketingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="essentials-alert__learn-more ml-auto font-weight-bold"
               >
                 <FormattedMessage
@@ -126,6 +128,15 @@ const EssentialsAlert = () => {
                 />
               </Button>
               )}
+            </div>
+
+            <div className="essentials-alert__tags">
+              {(product.tags || []).map((tag: string, index: number) => (
+                <span key={tag} className="essentials-alert__tag">
+                  {tag}
+                  {index < (product.tags || []).length - 1 && ' • '}
+                </span>
+              ))}
             </div>
 
             {academyDescription && (

--- a/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
@@ -131,12 +131,18 @@ const EssentialsAlert = () => {
             </div>
 
             <div className="essentials-alert__tags">
-              {(product.tags || []).map((tag: string, index: number) => (
-                <span key={tag} className="essentials-alert__tag">
-                  {tag}
-                  {index < (product.tags || []).length - 1 && ' • '}
-                </span>
-              ))}
+              {(product.tags || []).map((tag: any, index: number) => {
+                const label = typeof tag === 'string'
+                  ? tag
+                  : (tag.title || tag.title_en || tag.titleEn || tag.id || String(tag));
+                const key = typeof tag === 'string' ? tag : (tag.id ?? index);
+                return (
+                  <span key={key} className="essentials-alert__tag">
+                    {label}
+                    {index < (product.tags || []).length - 1 && ' • '}
+                  </span>
+                );
+              })}
             </div>
 
             {academyDescription && (

--- a/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
@@ -13,6 +13,8 @@ import { useCheckoutFormStore } from '@/hooks/useCheckoutFormStore';
 import './essentials-alert.scss';
 import { extractPriceByProductLookupKey } from '@/utils/checkout';
 
+import AcademyTags from './AcademyTags';
+
 const EssentialsAlert = () => {
   const {
     ESSENTIALS_PRODUCT_URL,
@@ -40,24 +42,6 @@ const EssentialsAlert = () => {
   const academyDescription = product.description || '';
   const academyMarketingUrl = product.marketingUrl ?? '';
   const courseCount = product.courseCount ?? 0;
-
-  const tags = product.tags ?? [];
-  let tagsElement: JSX.Element | null = null;
-  if (tags.length > 0) {
-    tagsElement = (
-      <div className="essentials-alert__tags">
-        {tags.map((tag: any, index: number, arr: any[]) => {
-          const label = typeof tag === 'string' ? tag : (tag.title || tag.title_en || tag.titleEn || '');
-          const key = tag && tag.id != null ? String(tag.id) : String(index);
-          return (
-            <span key={key} className="essentials-alert__tag">
-              {label}{index < arr.length - 1 && ' • '}
-            </span>
-          );
-        })}
-      </div>
-    );
-  }
 
   return (
     <Alert data-testid="essentials-alert" className="essentials-alert m-0 text-white p-0">
@@ -146,7 +130,7 @@ const EssentialsAlert = () => {
               )}
             </div>
 
-            {tagsElement}
+            <AcademyTags tags={product.tags ?? []} />
 
             {academyDescription && (
             <p className="essentials-alert__description m-0 font-weight-normal pt-3">

--- a/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/EssentialsAlert.tsx
@@ -41,6 +41,24 @@ const EssentialsAlert = () => {
   const academyMarketingUrl = product.marketingUrl ?? '';
   const courseCount = product.courseCount ?? 0;
 
+  const tags = product.tags ?? [];
+  let tagsElement: JSX.Element | null = null;
+  if (tags.length > 0) {
+    tagsElement = (
+      <div className="essentials-alert__tags">
+        {tags.map((tag: any, index: number, arr: any[]) => {
+          const label = typeof tag === 'string' ? tag : (tag.title || tag.title_en || tag.titleEn || '');
+          const key = tag && tag.id != null ? String(tag.id) : String(index);
+          return (
+            <span key={key} className="essentials-alert__tag">
+              {label}{index < arr.length - 1 && ' • '}
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <Alert data-testid="essentials-alert" className="essentials-alert m-0 text-white p-0">
       <div className="essentials-alert__header d-flex justify-content-between align-items-center pt-4 px-4">
@@ -117,8 +135,6 @@ const EssentialsAlert = () => {
               <Button
                 variant="link"
                 href={academyMarketingUrl}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="essentials-alert__learn-more ml-auto font-weight-bold"
               >
                 <FormattedMessage
@@ -130,20 +146,7 @@ const EssentialsAlert = () => {
               )}
             </div>
 
-            <div className="essentials-alert__tags">
-              {(product.tags || []).map((tag: any, index: number) => {
-                const label = typeof tag === 'string'
-                  ? tag
-                  : (tag.title || tag.title_en || tag.titleEn || tag.id || String(tag));
-                const key = typeof tag === 'string' ? tag : (tag.id ?? index);
-                return (
-                  <span key={key} className="essentials-alert__tag">
-                    {label}
-                    {index < (product.tags || []).length - 1 && ' • '}
-                  </span>
-                );
-              })}
-            </div>
+            {tagsElement}
 
             {academyDescription && (
             <p className="essentials-alert__description m-0 font-weight-normal pt-3">

--- a/src/components/plan-details-pages/EssentialsAlert/essentials-alert.scss
+++ b/src/components/plan-details-pages/EssentialsAlert/essentials-alert.scss
@@ -145,13 +145,24 @@
   }
 
   &__tags {
-    color: #666 !important;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    color: #333 !important;
   }
 
   &__tag {
-    color: #666;
+    color: #333;
     font-size: 13px;
     line-height: 1.6;
+
+    &:not(:last-child)::after {
+      content: '•';
+      margin-left: 4px;
+    }
   }
 
   &__description {

--- a/src/components/plan-details-pages/EssentialsAlert/tests/AcademyTags.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/AcademyTags.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+
+import AcademyTags from '../AcademyTags';
+
+describe('AcademyTags Component', () => {
+  it('renders nothing when tags is an empty array', () => {
+    const { container } = render(<AcademyTags tags={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders tag titles', () => {
+    render(<AcademyTags tags={[{ id: 1, title: 'sustainability' }]} />);
+    expect(screen.getByText('sustainability')).toBeInTheDocument();
+  });
+
+  it('renders tags in the supplied order', () => {
+    const { container } = render(
+      <AcademyTags
+        tags={[
+          { id: 1, title: 'sustainability' },
+          { id: 2, title: 'strategy' },
+          { id: 3, title: 'leadership' },
+        ]}
+      />,
+    );
+    const labels = Array.from(container.querySelectorAll('.essentials-alert__tag')).map(
+      (el) => el.textContent,
+    );
+    expect(labels).toEqual(['sustainability', 'strategy', 'leadership']);
+  });
+
+  it('renders multiple tags with the expected structure and classes', () => {
+    const { container } = render(
+      <AcademyTags
+        tags={[
+          { id: 1, title: 'sustainability' },
+          { id: 2, title: 'strategy' },
+        ]}
+      />,
+    );
+    expect(container.querySelector('ul.essentials-alert__tags')).toBeInTheDocument();
+    const items = container.querySelectorAll('li.essentials-alert__tag');
+    expect(items).toHaveLength(2);
+  });
+});

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -43,8 +43,8 @@ const mockProduct = {
   slug: 'sustainability-academy-yearly',
   courseCount: 12,
   tags: [
-    { id: 1, title_en: 'sustainability', description: 'Test tag1' },
-    { id: 2, title: 'strategy', description: 'Test tag2' },
+    { id: 1, title: 'sustainability', description: 'Test tag1', titleEn: 'sustainability' },
+    { id: 2, title: 'strategy', description: 'Test tag2', titleEn: 'strategy' },
   ],
 };
 
@@ -439,33 +439,6 @@ describe('EssentialsAlert Component', () => {
       expect(academyNames.length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText('8 courses')).toBeInTheDocument();
       expect(screen.getByText(/Master artificial intelligence fundamentals/)).toBeInTheDocument();
-    });
-
-    it('should render when tags are simple strings', () => {
-      const stringTagsProduct = {
-        ...mockProduct,
-        name: 'Strings',
-        longName: 'Strings Academy',
-        tags: ['alpha', 'beta', 'gamma'],
-      };
-
-      checkoutFormStore.setState((state) => ({
-        ...state,
-        formData: {
-          ...state.formData,
-          [DataStoreKey.AcademySelection]: {
-            selectedProduct: stringTagsProduct,
-          },
-        },
-      }));
-
-      renderComponent();
-      const alert = screen.getByTestId('essentials-alert');
-      const tagsContainer = alert.querySelector('.essentials-alert__tags');
-      expect(tagsContainer).toBeTruthy();
-      expect(tagsContainer).toHaveTextContent('alpha');
-      expect(tagsContainer).toHaveTextContent('beta');
-      expect(tagsContainer).toHaveTextContent('gamma');
     });
   });
 });

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -42,6 +42,7 @@ const mockProduct = {
   lookupKey: 'essentials_artificial_intelligence_subscription_license_yearly',
   slug: 'sustainability-academy-yearly',
   courseCount: 12,
+  tags: ['sustainability', 'strategy'],
 };
 
 describe('EssentialsAlert Component', () => {
@@ -175,6 +176,10 @@ describe('EssentialsAlert Component', () => {
       const learnMoreLink = screen.getByText('Learn more');
       expect(learnMoreLink).toBeInTheDocument();
       expect(learnMoreLink.tagName).toBe('A');
+      // Learn more should open in a new tab
+      expect((learnMoreLink as HTMLAnchorElement).target).toBe('_blank');
+      expect((learnMoreLink as HTMLAnchorElement).rel).toContain('noopener');
+      expect((learnMoreLink as HTMLAnchorElement).rel).toContain('noreferrer');
     });
 
     it('should display academy description', () => {
@@ -264,6 +269,18 @@ describe('EssentialsAlert Component', () => {
       const learnMoreLink = screen.getByText('Learn more') as HTMLAnchorElement;
       expect(learnMoreLink).toBeInTheDocument();
       expect(learnMoreLink.href).toBe('https://www.edx.org/learn/sustainability');
+      expect(learnMoreLink.target).toBe('_blank');
+      expect(learnMoreLink.rel).toContain('noopener');
+      expect(learnMoreLink.rel).toContain('noreferrer');
+    });
+
+    it('should render product tags when available', () => {
+      renderComponent();
+      const alert = screen.getByTestId('essentials-alert');
+      const tagsContainer = alert.querySelector('.essentials-alert__tags');
+      expect(tagsContainer).toBeTruthy();
+      expect(tagsContainer).toHaveTextContent('sustainability');
+      expect(tagsContainer).toHaveTextContent('strategy');
     });
   });
 

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -42,7 +42,10 @@ const mockProduct = {
   lookupKey: 'essentials_artificial_intelligence_subscription_license_yearly',
   slug: 'sustainability-academy-yearly',
   courseCount: 12,
-  tags: ['sustainability', 'strategy'],
+  tags: [
+    { id: 1, title_en: 'sustainability', description: 'Test tag1' },
+    { id: 2, title: 'strategy', description: 'Test tag2' },
+  ],
 };
 
 describe('EssentialsAlert Component', () => {

--- a/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/EssentialsAlert.test.tsx
@@ -153,6 +153,49 @@ describe('EssentialsAlert Component', () => {
       expect(academyNames.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('should not render tags section when tags are missing or empty', () => {
+      // Case: tags undefined
+      checkoutFormStore.setState((state) => ({
+        ...state,
+        formData: {
+          ...state.formData,
+          [DataStoreKey.AcademySelection]: { selectedProduct: { ...mockProduct, tags: undefined } },
+        },
+      }));
+
+      const { rerender } = render(
+        <MemoryRouter>
+          <AppContext.Provider value={mockContextValue as any}>
+            <IntlProvider locale="en" messages={{}}>
+              <EssentialsAlert />
+            </IntlProvider>
+          </AppContext.Provider>
+        </MemoryRouter>,
+      );
+      expect(screen.queryByText('sustainability')).not.toBeInTheDocument();
+      expect(screen.queryByText('strategy')).not.toBeInTheDocument();
+
+      // Case: tags empty array
+      checkoutFormStore.setState((state) => ({
+        ...state,
+        formData: {
+          ...state.formData,
+          [DataStoreKey.AcademySelection]: { selectedProduct: { ...mockProduct, tags: [] } },
+        },
+      }));
+      rerender(
+        <MemoryRouter>
+          <AppContext.Provider value={mockContextValue as any}>
+            <IntlProvider locale="en" messages={{}}>
+              <EssentialsAlert />
+            </IntlProvider>
+          </AppContext.Provider>
+        </MemoryRouter>,
+      );
+      expect(screen.queryByText('sustainability')).not.toBeInTheDocument();
+      expect(screen.queryByText('strategy')).not.toBeInTheDocument();
+    });
+
     it('should fall back to product name when longName is missing', () => {
       checkoutFormStore.setState((state) => ({
         ...state,
@@ -179,10 +222,8 @@ describe('EssentialsAlert Component', () => {
       const learnMoreLink = screen.getByText('Learn more');
       expect(learnMoreLink).toBeInTheDocument();
       expect(learnMoreLink.tagName).toBe('A');
-      // Learn more should open in a new tab
-      expect((learnMoreLink as HTMLAnchorElement).target).toBe('_blank');
-      expect((learnMoreLink as HTMLAnchorElement).rel).toContain('noopener');
-      expect((learnMoreLink as HTMLAnchorElement).rel).toContain('noreferrer');
+      // Learn more should open in the same tab (no target)
+      expect((learnMoreLink as HTMLAnchorElement).target).toBe('');
     });
 
     it('should display academy description', () => {
@@ -272,9 +313,7 @@ describe('EssentialsAlert Component', () => {
       const learnMoreLink = screen.getByText('Learn more') as HTMLAnchorElement;
       expect(learnMoreLink).toBeInTheDocument();
       expect(learnMoreLink.href).toBe('https://www.edx.org/learn/sustainability');
-      expect(learnMoreLink.target).toBe('_blank');
-      expect(learnMoreLink.rel).toContain('noopener');
-      expect(learnMoreLink.rel).toContain('noreferrer');
+      expect(learnMoreLink.target).toBe('');
     });
 
     it('should render product tags when available', () => {
@@ -400,6 +439,33 @@ describe('EssentialsAlert Component', () => {
       expect(academyNames.length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText('8 courses')).toBeInTheDocument();
       expect(screen.getByText(/Master artificial intelligence fundamentals/)).toBeInTheDocument();
+    });
+
+    it('should render when tags are simple strings', () => {
+      const stringTagsProduct = {
+        ...mockProduct,
+        name: 'Strings',
+        longName: 'Strings Academy',
+        tags: ['alpha', 'beta', 'gamma'],
+      };
+
+      checkoutFormStore.setState((state) => ({
+        ...state,
+        formData: {
+          ...state.formData,
+          [DataStoreKey.AcademySelection]: {
+            selectedProduct: stringTagsProduct,
+          },
+        },
+      }));
+
+      renderComponent();
+      const alert = screen.getByTestId('essentials-alert');
+      const tagsContainer = alert.querySelector('.essentials-alert__tags');
+      expect(tagsContainer).toBeTruthy();
+      expect(tagsContainer).toHaveTextContent('alpha');
+      expect(tagsContainer).toHaveTextContent('beta');
+      expect(tagsContainer).toHaveTextContent('gamma');
     });
   });
 });


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-12022

Steps to Reproduce:

Navigate to Plan  Details page in Essentials flow.
Fetching Tags from API response  in  Essential Alert box.
 
 
<img width="1258" height="575" alt="image" src="https://github.com/user-attachments/assets/32ed1b75-d628-45dc-ba94-56472648413a" />

<img width="1244" height="567" alt="image" src="https://github.com/user-attachments/assets/0653eeec-9df6-404d-8c1c-cda643cf828a" />

