### PR TITLE
chore: sync AI instruction files from enterprise template

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,3 +10,66 @@ At the start of every session, before doing any other work, read:
 
 Treat their contents as binding project instructions for the remainder of the
 session, equivalent to instructions in this file.
+
+## PR Review Instructions
+
+When reviewing a PR, run three sequential concern passes and emit a structured verdict. Bias
+toward flagging **excess and redundancy**, not absence — this is the opposite polarity from
+default LLM review, and it is intentional.
+
+### Pass 1 — Architecture fit (House Rules)
+
+Search outside the diff when applying these rules.
+
+1. **Reuse before reinvent.** Before flagging new code as a duplicate, you must be able to name
+   the existing equivalent symbol and its file path. If you cannot name it, do not flag it.
+2. **Earn every guard.** Defensive code (try/except, null-checks, fallbacks) must address a
+   failure that can actually happen at this call site given the system's invariants. Flag guards
+   against impossible states and fallbacks that mask real errors.
+3. **YAGNI / trust the defaults.** Don't build for hypothetical futures. Don't re-implement what
+   the framework already does (DRF pagination, auth, serializer defaults). Flag speculative
+   generality and needless overrides of correct defaults.
+4. **Respect the source of truth.** Data should be read from its canonical owner. Flag calls to
+   external services for data the system already stores locally (e.g. a live Stripe price lookup
+   when a local price table keyed by slug exists). Name the local source you're pointing to.
+
+For every finding: cite `file:line`. For rules 1 & 4: name the existing symbol and its path or
+drop the finding. Severity: critical | moderate | minor.
+
+### Pass 2 — Security
+
+Check auth/permission classes, input validation at trust boundaries, injection vectors, secrets
+in code, missing PII annotations, CSRF. For Django/DRF backends: verify `edx-drf-extensions`
+and `edx-rbac` patterns. For React frontends: check XSS vectors and exposed keys. Cite
+`file:line` for every finding.
+
+### Pass 3 — Test coverage
+
+Flag new logic shipped without tests, tests that assert implementation detail rather than
+behavior, missing edge cases (empty input, permission denied, partial failure), and brittle
+snapshot tests.
+
+### Output format
+
+```
+HEADLINE: <one sentence — the single most important takeaway for triage>
+
+## House-Rule Findings
+| Rule | Severity | Location | Finding | Should have used |
+|------|----------|----------|---------|-----------------|
+| Reuse before reinvent | moderate | billing/calc.py:42 | reimplements currency formatting | billing/utils.py:format_currency |
+
+## Security & Tests
+1) <severity> <file:line> — <claim>
+
+HOTSPOTS:
+1) <file:symbol> — <why risky or hard to read>
+
+MERGE_READINESS: READY | CHANGES_REQUIRED | REJECT_SCOPE
+<one-sentence rationale>
+```
+
+- **READY**: no confirmed critical or moderate findings.
+- **CHANGES_REQUIRED**: confirmed findings need addressing before merge.
+- **REJECT_SCOPE**: PR exceeds 400 effective LoC or 10 effective files (excluding tests,
+  lockfiles, generated files, migrations). Propose a split instead of a full review.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,5 +71,6 @@ MERGE_READINESS: READY | CHANGES_REQUIRED | REJECT_SCOPE
 
 - **READY**: no confirmed critical or moderate findings.
 - **CHANGES_REQUIRED**: confirmed findings need addressing before merge.
-- **REJECT_SCOPE**: PR exceeds 400 effective LoC or 10 effective files (excluding tests,
-  lockfiles, generated files, migrations). Propose a split instead of a full review.
+- **REJECT_SCOPE**: PR exceeds the effective LoC/file threshold defined in this repo's
+  `CLAUDE.md` under "## Before opening a PR or pushing a branch". Propose a split instead
+  of a full review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,5 +160,5 @@ All forms use react-hook-form with zod validation schemas:
 Run a self-check on the diff before creating a PR or pushing:
 1. Compute effective LoC — exclude lockfiles, generated files, snapshots, and vendor code.
 2. Count effective touched files — exclude the above plus one-to-one test pairs.
-3. If effective LoC > 400 or effective files > 10, stop and propose a split before proceeding.
+3. If effective LoC > 1000 or effective files > 25, stop and propose a split before proceeding.
 4. Report the result inline before continuing.


### PR DESCRIPTION
## Summary

Syncs boilerplate sections of `CLAUDE.md` and `.github/copilot-instructions.md` with the latest conventions from [edx/ai-devtools-internal](https://github.com/edx/ai-devtools-internal) `docs/templates/`.

### Changed sections
- Updated CLAUDE.md: ## Before opening a PR or pushing a branch (400 LoC/10 files → 1000 LoC/25 files)
- Updated .github/copilot-instructions.md — adds the `## PR Review Instructions` section, and points its `REJECT_SCOPE` line at `CLAUDE.md`'s threshold instead of restating a hardcoded number

### Why not just fix the number?

`copilot-instructions.md`'s `REJECT_SCOPE` line and `CLAUDE.md`'s "Before opening a PR" section encode the same PR-size gate — restating it as a second hardcoded number is duplicative in both language ("stop and propose a split" vs. "propose a split instead of a full review") and implementation (both enforce the same effective-LoC/file ceiling). That duplication is exactly what let this go stale: the frontend threshold changed to 1000/25, and `copilot-instructions.md`'s copy of the number didn't, because nothing kept them in sync.

Restoring a hardcoded number here instead of referencing `CLAUDE.md` would mean forking `copilot-instructions.md.template` per repo type — which requires `compare.py`/`apply.py` to gain `--type` branching for this file (currently loaded unconditionally, no type awareness), a second near-duplicate template to maintain in lockstep, and reverting the design rule that this file is "applied identically to all repos." That's a materially larger change than the one-line reference fix, and it reintroduces the exact duplication that caused this drift in the first place — just with twice as many places for it to drift again.

### No repo-specific content was modified
Repo-specific sections (`## Overview`, `## Architecture Overview`, etc.) were not touched.

🤖 Generated by the `update-ai-instructions` skill.
