### PR TITLE
feat: ENT-12068 display Essentials subscription type

### DIFF
--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/BillingDetailsHeadingMessage.tsx
@@ -2,12 +2,15 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Container, Image, Stack } from '@openedx/paragon';
 
 import { usePolledAuthenticatedUser, usePolledCheckoutIntent } from '@/components/app/data';
+import useCheckoutIntent from '@/components/app/data/hooks/useCheckoutIntent';
 import { isEssentialsFlow } from '@/components/app/routes/loaders/utils';
 
 import Celebration from './images/celebration.svg';
 
 const ErrorHeading = () => {
-  const isEssentials = isEssentialsFlow();
+  const { data: checkoutIntent } = useCheckoutIntent();
+  // Use productType from backend (ENT-12069), fallback to sessionStorage heuristic for backward compatibility
+  const productType = checkoutIntent?.productType || (isEssentialsFlow() ? 'Essentials' : 'Team');
   return (
     <>
       <h2 className="text-center font-weight-normal mb-0">
@@ -23,7 +26,7 @@ const ErrorHeading = () => {
           defaultMessage="We're experiencing a brief delay in setting up your {productName} account. We'll send you a confirmation email immediately once your account is fully operational. Thank you for your patience!"
           description="Description text explaining the error account setup status"
           values={{
-            productName: isEssentials ? 'edX Essentials' : 'edX Team',
+            productName: `edX ${productType}`,
           }}
         />
       </p>
@@ -32,7 +35,9 @@ const ErrorHeading = () => {
 };
 
 const InactiveUserHeading = () => {
-  const isEssentials = isEssentialsFlow();
+  const { data: checkoutIntent } = useCheckoutIntent();
+  // Use productType from backend (ENT-12069), fallback to sessionStorage heuristic for backward compatibility
+  const productType = checkoutIntent?.productType || (isEssentialsFlow() ? 'Essentials' : 'Team');
   return (
     <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
@@ -40,7 +45,7 @@ const InactiveUserHeading = () => {
         defaultMessage="Welcome to {productName}! Please check your email to complete the account confirmation process."
         description="Description text explaining that user needs to verify their email"
         values={{
-          productName: isEssentials ? 'edX for Essentials' : 'edX for Team',
+          productName: `edX for ${productType}`,
         }}
       />
     </p>
@@ -48,7 +53,9 @@ const InactiveUserHeading = () => {
 };
 
 const PendingHeading = () => {
-  const isEssentials = isEssentialsFlow();
+  const { data: checkoutIntent } = useCheckoutIntent();
+  // Use productType from backend (ENT-12069), fallback to sessionStorage heuristic for backward compatibility
+  const productType = checkoutIntent?.productType || (isEssentialsFlow() ? 'Essentials' : 'Team');
   return (
     <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
@@ -56,7 +63,7 @@ const PendingHeading = () => {
         defaultMessage="Welcome to {productName}! Your account is currently being configured. We'll send you an email once everything is ready and you can begin onboarding and inviting your team members to start learning."
         description="Description text explaining the pending account setup status"
         values={{
-          productName: isEssentials ? 'edX for Essentials' : 'edX for Team',
+          productName: `edX for ${productType}`,
         }}
       />
     </p>
@@ -64,7 +71,9 @@ const PendingHeading = () => {
 };
 
 const SuccessHeading = () => {
-  const isEssentials = isEssentialsFlow();
+  const { data: checkoutIntent } = useCheckoutIntent();
+  // Use productType from backend (ENT-12069), fallback to sessionStorage heuristic for backward compatibility
+  const productType = checkoutIntent?.productType || (isEssentialsFlow() ? 'Essentials' : 'Team');
   return (
     <p className="fs-4 font-weight-light text-center">
       <FormattedMessage
@@ -72,7 +81,7 @@ const SuccessHeading = () => {
         defaultMessage="Welcome to {productName}! Go to your administrator dashboard to onboard and invite your team members to start learning."
         description="Description text explaining the success account setup status"
         values={{
-          productName: isEssentials ? 'edX for Essentials' : 'edX for Team',
+          productName: `edX for ${productType}`,
         }}
       />
     </p>

--- a/src/components/billing-details-pages/BillingDetailsHeadingMessage/tests/BillingDetailsHeadingMessage.test.tsx
+++ b/src/components/billing-details-pages/BillingDetailsHeadingMessage/tests/BillingDetailsHeadingMessage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { usePolledAuthenticatedUser, usePolledCheckoutIntent } from '@/components/app/data';
+import useCheckoutIntent from '@/components/app/data/hooks/useCheckoutIntent';
 
 import BillingDetailsHeadingMessage from '../BillingDetailsHeadingMessage';
 
@@ -12,10 +13,16 @@ jest.mock('@/components/app/data', () => ({
   usePolledAuthenticatedUser: jest.fn(),
 }));
 
+jest.mock('@/components/app/data/hooks/useCheckoutIntent', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const mockUsePolledCheckoutIntent = usePolledCheckoutIntent as jest.MockedFunction<typeof usePolledCheckoutIntent>;
 const mockUsePolledAuthenticatedUser = (
   usePolledAuthenticatedUser as jest.MockedFunction<typeof usePolledAuthenticatedUser>
 );
+const mockUseCheckoutIntent = useCheckoutIntent as jest.MockedFunction<typeof useCheckoutIntent>;
 
 describe('BillingDetailsHeadingMessage', () => {
   const renderComponent = () => render(
@@ -26,6 +33,10 @@ describe('BillingDetailsHeadingMessage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
+    mockUseCheckoutIntent.mockReturnValue({
+      data: { productType: null },
+    } as any);
   });
 
   it('renders the celebration image', () => {
@@ -55,6 +66,54 @@ describe('BillingDetailsHeadingMessage', () => {
     renderComponent();
     expect(screen.getByText(/Welcome to edX for Team/)).toBeInTheDocument();
     expect(screen.getByText(/Go to your administrator dashboard/)).toBeInTheDocument();
+  });
+
+  it('renders Teams when checkoutIntent.productType is Teams', () => {
+    mockUseCheckoutIntent.mockReturnValue({
+      data: { productType: 'Teams' },
+    } as any);
+    mockUsePolledCheckoutIntent.mockReturnValue({
+      polledCheckoutIntent: { state: 'fulfilled' },
+    } as any);
+    mockUsePolledAuthenticatedUser.mockReturnValue({
+      polledAuthenticatedUser: { isActive: true },
+    } as any);
+
+    renderComponent();
+
+    expect(screen.getByText(/Welcome to edX for Teams!/)).toBeInTheDocument();
+  });
+
+  it('renders Essentials when checkoutIntent.productType is Essentials', () => {
+    mockUseCheckoutIntent.mockReturnValue({
+      data: { productType: 'Essentials' },
+    } as any);
+    mockUsePolledCheckoutIntent.mockReturnValue({
+      polledCheckoutIntent: { state: 'fulfilled' },
+    } as any);
+    mockUsePolledAuthenticatedUser.mockReturnValue({
+      polledAuthenticatedUser: { isActive: true },
+    } as any);
+
+    renderComponent();
+
+    expect(screen.getByText(/Welcome to edX for Essentials!/)).toBeInTheDocument();
+  });
+
+  it('falls back to the existing Team copy when checkoutIntent.productType is null', () => {
+    mockUseCheckoutIntent.mockReturnValue({
+      data: { productType: null },
+    } as any);
+    mockUsePolledCheckoutIntent.mockReturnValue({
+      polledCheckoutIntent: { state: 'fulfilled' },
+    } as any);
+    mockUsePolledAuthenticatedUser.mockReturnValue({
+      polledAuthenticatedUser: { isActive: true },
+    } as any);
+
+    renderComponent();
+
+    expect(screen.getByText(/Welcome to edX for Team/)).toBeInTheDocument();
   });
 
   it('renders PendingHeading when checkout is paid and user is active', () => {

--- a/src/components/billing-details-pages/OrderDetails/OrderDetailsHeading.tsx
+++ b/src/components/billing-details-pages/OrderDetails/OrderDetailsHeading.tsx
@@ -1,9 +1,12 @@
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
+import { useCheckoutIntent } from '@/components/app/data';
 import { isEssentialsFlow } from '@/components/app/routes/loaders/utils';
 
 const OrderDetailsHeading: React.FC = () => {
-  const isEssentials = isEssentialsFlow();
+  const { data: checkoutIntent } = useCheckoutIntent();
+  // Use productType from backend (ENT-12069), fallback to sessionStorage heuristic for backward compatibility
+  const productType = checkoutIntent?.productType || (isEssentialsFlow() ? 'Essentials' : 'Team');
   return (
     <>
       <h3 className="mb-2">
@@ -19,7 +22,7 @@ const OrderDetailsHeading: React.FC = () => {
           defaultMessage="You have purchased an edX {productName} subscription."
           description="Description text explaining the order details"
           values={{
-            productName: isEssentials ? 'Essentials' : 'Team',
+            productName: productType,
           }}
         />
       </p>

--- a/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
+++ b/src/components/billing-details-pages/OrderDetails/tests/OrderDetails.test.tsx
@@ -130,6 +130,39 @@ describe('OrderDetails', () => {
       validateText(expectedText);
     });
 
+    it('renders Teams from checkoutIntent.productType when provided', () => {
+      (useCheckoutIntent as jest.Mock).mockReturnValue({
+        data: { id: 'test-checkout-intent-id', productType: 'Teams' },
+        isLoading: false,
+      });
+
+      renderComponent();
+
+      validateText('You have purchased an edX Teams subscription.');
+    });
+
+    it('renders Essentials from checkoutIntent.productType when provided', () => {
+      (useCheckoutIntent as jest.Mock).mockReturnValue({
+        data: { id: 'test-checkout-intent-id', productType: 'Essentials' },
+        isLoading: false,
+      });
+
+      renderComponent();
+
+      validateText('You have purchased an edX Essentials subscription.');
+    });
+
+    it('falls back to the existing Team copy when checkoutIntent.productType is null', () => {
+      (useCheckoutIntent as jest.Mock).mockReturnValue({
+        data: { id: 'test-checkout-intent-id', productType: null },
+        isLoading: false,
+      });
+
+      renderComponent();
+
+      validateText('You have purchased an edX Team subscription.');
+    });
+
     it('renders all section headings', () => {
       (useFirstBillableInvoice as jest.Mock).mockReturnValue({
         data: {

--- a/src/components/billing-details-pages/SubscriptionStartMessage/SubscriptionStartMessage.tsx
+++ b/src/components/billing-details-pages/SubscriptionStartMessage/SubscriptionStartMessage.tsx
@@ -28,11 +28,12 @@ const messages = defineMessages({
 
 export const SubscriptionStartMessage = () => {
   const intl = useIntl();
-  const isEssentials = isEssentialsFlow();
   const { data: firstBillableInvoice, isLoading } = useFirstBillableInvoice();
   // TODO: Add this endpoint to the success page loader
   const { data: billingPortalSession } = useCreateBillingPortalSession();
   const { data: checkoutIntent } = useCheckoutIntent();
+  // Use productType from backend (ENT-12069), fallback to sessionStorage heuristic for backward compatibility
+  const productType = checkoutIntent?.productType || (isEssentialsFlow() ? 'Essentials' : 'Team');
   const { yearlySubscriptionCostForQuantity } = usePurchaseSummaryPricing();
 
   if (isLoading || !firstBillableInvoice) {
@@ -59,7 +60,7 @@ export const SubscriptionStartMessage = () => {
             description="Title for the free trial success field section"
             values={{
               trialDays: SUBSCRIPTION_TRIAL_LENGTH_DAYS,
-              productName: isEssentials ? 'edX Essentials' : 'edX Team',
+              productName: `edX ${productType}`,
             }}
           />
         </h3>

--- a/src/components/billing-details-pages/SubscriptionStartMessage/tests/SubscriptionStartMessage.test.tsx
+++ b/src/components/billing-details-pages/SubscriptionStartMessage/tests/SubscriptionStartMessage.test.tsx
@@ -83,10 +83,49 @@ describe('SubscriptionStartMessage', () => {
     validateText('Your free 14-day trial for edX Team subscription has started.');
   });
 
+  it('renders the title from checkoutIntent.productType when it is Teams', () => {
+    (useCheckoutIntent as jest.Mock).mockReturnValue({
+      data: {
+        id: 7,
+        productType: 'Teams',
+      },
+    });
+
+    renderComponent();
+
+    validateText('Your free 14-day trial for edX Teams subscription has started.');
+  });
+
   it('renders the title correctly for Essentials flow', () => {
     sessionStorage.setItem('isEssentials', 'true');
     renderComponent();
     validateText('Your free 14-day trial for edX Essentials subscription has started.');
+  });
+
+  it('renders the title from checkoutIntent.productType when it is Essentials', () => {
+    (useCheckoutIntent as jest.Mock).mockReturnValue({
+      data: {
+        id: 7,
+        productType: 'Essentials',
+      },
+    });
+
+    renderComponent();
+
+    validateText('Your free 14-day trial for edX Essentials subscription has started.');
+  });
+
+  it('falls back to the existing Team copy when checkoutIntent.productType is null', () => {
+    (useCheckoutIntent as jest.Mock).mockReturnValue({
+      data: {
+        id: 7,
+        productType: null,
+      },
+    });
+
+    renderComponent();
+
+    validateText('Your free 14-day trial for edX Team subscription has started.');
   });
 
   it('renders the description message correctly', () => {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -308,6 +308,7 @@ declare global {
     expiresAt: string;
     adminPortalUrl: string;
     country: string | null;
+    productType: string | null;
   }
 
   type BillingAddress = {


### PR DESCRIPTION
**TITLE**
### **ENT-12068: Display subscription product type from checkout context**

https://2u-internal.atlassian.net/browse/ENT-12068

### **Summary**

This PR implements ENT-12068 by updating the checkout success and billing experience to display the subscription product type using the backend-provided productType field introduced in ENT-12069. Previously, the UI relied on hardcoded Teams/Essentials logic and session-based heuristics. With this change, the frontend now uses checkoutIntent.productType as the source of truth when rendering subscription-related product text.

To maintain backward compatibility, if productType is missing or null, the existing isEssentialsFlow() logic is preserved so that legacy checkout flows continue to work without regression.

### **Changes**
Added productType to the checkout context type.
Updated billing success components (OrderDetailsHeading, SubscriptionStartMessage, and BillingDetailsHeadingMessage) to display Teams or Essentials based on checkoutIntent.productType.
Preserved the existing fallback behavior for environments where the backend field is not available.
Added and updated unit tests covering:
Teams (productType = "teams")
Essentials (productType = "essentials")
Missing/null productType fallback behavior
Backend Dependency

This PR depends on ENT-12069, which exposes the productType (product_type in the API response) in the checkout context API. The frontend consumes this new field to display the correct subscription product name while maintaining compatibility with existing customers.

### **Testing**
 npm run check-types
 npm run lint
 Updated unit tests passed (44 tests across 3 test suites)
 Manually verified product type rendering for Teams and Essentials scenarios, along with fallback behavior.