### PR TITLE
feat: limit tags display

### DIFF
--- a/src/components/plan-details-pages/EssentialsAlert/AcademyTags.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/AcademyTags.tsx
@@ -14,7 +14,7 @@ const AcademyTags = ({ tags }: AcademyTagsProps) => {
 
   return (
     <ul className="essentials-alert__tags">
-      {tags.map(({ id, title }) => (
+      {tags.slice(0, 3).map(({ id, title }) => (
         <li key={id} className="essentials-alert__tag">{title}</li>
       ))}
     </ul>

--- a/src/components/plan-details-pages/EssentialsAlert/tests/AcademyTags.test.tsx
+++ b/src/components/plan-details-pages/EssentialsAlert/tests/AcademyTags.test.tsx
@@ -42,4 +42,26 @@ describe('AcademyTags Component', () => {
     const items = container.querySelectorAll('li.essentials-alert__tag');
     expect(items).toHaveLength(2);
   });
+
+  it('renders only the first 3 tags when more than 3 are provided', () => {
+    const tags = [
+      { id: 1, title: 'sustainability' },
+      { id: 2, title: 'strategy' },
+      { id: 3, title: 'leadership' },
+      { id: 4, title: 'engineering' },
+      { id: 5, title: 'marketing' },
+    ];
+
+    const { container } = render(<AcademyTags tags={tags} />);
+
+    const items = container.querySelectorAll('li.essentials-alert__tag');
+    expect(items).toHaveLength(3);
+
+    expect(screen.getByText('sustainability')).toBeInTheDocument();
+    expect(screen.getByText('strategy')).toBeInTheDocument();
+    expect(screen.getByText('leadership')).toBeInTheDocument();
+
+    expect(screen.queryByText('engineering')).not.toBeInTheDocument();
+    expect(screen.queryByText('marketing')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
**Description**
Limits the number of tags displayed to a maximum of 3 to prevent UI overflow and maintain consistent card/component layout.

**Ticket** : [12022](https://2u-internal.atlassian.net/browse/ENT-12022) 

**Changes**
Added .slice(0, 3) to the tags array before mapping, so only the first 3 tags render.

**Before**
All tags rendered regardless of count, causing layout issues when many tags were present.

**After**
Only the first 3 tags are displayed, keeping the UI clean and consistent.

<img width="1220" height="549" alt="image" src="https://github.com/user-attachments/assets/6e7f868c-0818-4010-be31-6df7fbe00bc6" />
