### PR TITLE
chore: add a local stage development subsection under local development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,11 @@ Configured path aliases for cleaner imports:
 - Requires devstack and enterprise-access service running
 - See README.rst for complete setup instructions including required enterprise-access settings
 
+### Local Stage Development
+
+- Runs on `localhost.stage.edx.org:1989`
+- Start with: `npm run start:stage`
+
 ### State Management
 
 - **Server State**: TanStack Query with 20-second stale time and retry logic


### PR DESCRIPTION
## Summary

Add a Local Stage Development subsection under Local Development, documenting the stage host/port (`localhost.stage.edx.org:1989`, matching this repo's existing local port) and the staging start command (`npm run start:stage`).

**File changed:** `CLAUDE.md`

🤖 Generated by the `cross-repo-patch` skill.