### PR TITLE
feat: display upgrade to teams button on registration

### DIFF
--- a/src/components/PurchaseSummary/PurchaseSummaryCardButton.tsx
+++ b/src/components/PurchaseSummary/PurchaseSummaryCardButton.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { CheckoutPageRoute, EssentialsPageRoute } from '@/constants/checkout';
+import { CheckoutPageRoute, CheckoutSubstepKey, EssentialsPageRoute } from '@/constants/checkout';
 
 import EditPlanButton from './EditPlanButton';
 import ReceiptButton from './ReceiptButton';
@@ -25,6 +25,7 @@ const ROUTE_BUTTON_MAP: Record<string, ButtonType> = {
   [CheckoutPageRoute.PlanDetailsRegister]: BUTTON_TYPES.NONE,
   [EssentialsPageRoute.AcademicSelection]: BUTTON_TYPES.UPGRADE,
   [EssentialsPageRoute.PlanDetails]: BUTTON_TYPES.UPGRADE,
+  [`${EssentialsPageRoute.PlanDetails}/${CheckoutSubstepKey.Register}`]: BUTTON_TYPES.UPGRADE,
   [EssentialsPageRoute.AccountDetails]: BUTTON_TYPES.UPGRADE,
   [EssentialsPageRoute.BillingDetails]: BUTTON_TYPES.UPGRADE,
   [EssentialsPageRoute.BillingDetailsSuccess]: BUTTON_TYPES.RECEIPT,

--- a/src/components/PurchaseSummary/PurchaseSummaryCardButton.tsx
+++ b/src/components/PurchaseSummary/PurchaseSummaryCardButton.tsx
@@ -22,7 +22,7 @@ const ROUTE_BUTTON_MAP: Record<string, ButtonType> = {
   [CheckoutPageRoute.BillingDetailsSuccess]: BUTTON_TYPES.RECEIPT,
   [CheckoutPageRoute.PlanDetails]: BUTTON_TYPES.NONE,
   [CheckoutPageRoute.PlanDetailsLogin]: BUTTON_TYPES.NONE,
-  [CheckoutPageRoute.PlanDetailsRegister]: BUTTON_TYPES.NONE,
+  [CheckoutPageRoute.PlanDetailsRegister]: BUTTON_TYPES.NONE, // Already in the Teams checkout flow — no upgrade needed.
   [EssentialsPageRoute.AcademicSelection]: BUTTON_TYPES.UPGRADE,
   [EssentialsPageRoute.PlanDetails]: BUTTON_TYPES.UPGRADE,
   [`${EssentialsPageRoute.PlanDetails}/${CheckoutSubstepKey.Register}`]: BUTTON_TYPES.UPGRADE,

--- a/src/components/PurchaseSummary/tests/PurchaseSummaryCardButton.test.tsx
+++ b/src/components/PurchaseSummary/tests/PurchaseSummaryCardButton.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
-import { CheckoutPageRoute, EssentialsPageRoute } from '@/constants/checkout';
+import { CheckoutPageRoute, CheckoutSubstepKey, EssentialsPageRoute } from '@/constants/checkout';
 
 import PurchaseSummaryCardButton from '../PurchaseSummaryCardButton';
 
@@ -106,8 +106,14 @@ describe('PurchaseSummaryCardButton', () => {
   });
 
   describe('Essentials Routes', () => {
-    it('renders upgrade button for essentials plan details route', () => {
-      renderWithRouter(EssentialsPageRoute.PlanDetails);
+    it.each([
+      EssentialsPageRoute.AcademicSelection,
+      EssentialsPageRoute.PlanDetails,
+      `${EssentialsPageRoute.PlanDetails}/${CheckoutSubstepKey.Register}`,
+      EssentialsPageRoute.AccountDetails,
+      EssentialsPageRoute.BillingDetails,
+    ])('renders upgrade button for essentials route: %s', (route) => {
+      renderWithRouter(route);
 
       expect(screen.getByTestId('upgrade-to-teams-button')).toBeInTheDocument();
       expect(screen.getByText('Upgrade to Teams')).toBeInTheDocument();

--- a/src/components/PurchaseSummary/tests/PurchaseSummaryCardButton.test.tsx
+++ b/src/components/PurchaseSummary/tests/PurchaseSummaryCardButton.test.tsx
@@ -94,6 +94,8 @@ describe('PurchaseSummaryCardButton', () => {
       expect(screen.queryByTestId('edit-plan-button')).not.toBeInTheDocument();
       expect(screen.queryByText('Edit Plan')).not.toBeInTheDocument();
       expect(screen.queryByText('View Receipt')).not.toBeInTheDocument();
+      // Ensure PlanDetailsRegister does NOT render the Essentials upgrade button
+      expect(screen.queryByTestId('upgrade-to-teams-button')).not.toBeInTheDocument();
     });
 
     it('renders nothing for unknown/unmapped routes', () => {


### PR DESCRIPTION
**Summary**

Fixes a missing "Upgrade to Teams" button in the Purchase Summary Card on the enterprise checkout registration page. The button was not rendering during the registration flow despite being applicable in that context.(As per ticket [https://2u-internal.atlassian.net/browse/ENT-12142](https://2u-internal.atlassian.net/browse/ENT-12142) 

**Changes**

Updated PurchaseSummaryCardButton to render the "Upgrade to Teams" button when the user is on the registration step of the  checkout flow


<img width="1244" height="562" alt="image" src="https://github.com/user-attachments/assets/6b895e07-c58a-4db3-b66d-4d9925ad9d9c" />

