### PR TITLE
feat: added linkout icon for contact support

### DIFF
--- a/src/components/billing-details-pages/ContactSupport/ContactSupport.tsx
+++ b/src/components/billing-details-pages/ContactSupport/ContactSupport.tsx
@@ -1,8 +1,8 @@
 import { getConfig } from '@edx/frontend-platform/config';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Hyperlink } from '@openedx/paragon';
 
 import { useCheckoutIntent } from '@/components/app/data';
+import { ExternalLink } from '@/components/ExternalLink';
 import EVENT_NAMES from '@/constants/events';
 import { sendEnterpriseCheckoutTrackingEvent } from '@/utils/common';
 
@@ -10,31 +10,29 @@ const ContactSupport = () => {
   const { CONTACT_SUPPORT_URL } = getConfig();
   const { data: checkoutIntent } = useCheckoutIntent();
   return (
-    <div className="text-left w-50 mx-auto">
+    <div className="text-left w-75 mx-auto">
       <p className="text-muted mb-0">
         <FormattedMessage
           id="checkout.orderDetails.needHelp"
-          defaultMessage="For questions about your subscription or our cancellation procedures, please {contactSupport}"
+          defaultMessage="For questions about your subscription or our{lineBreak}cancellation procedures, please {contactSupport}"
           description="Help text with link to contact support"
           values={{
+            lineBreak: <span style={{ display: 'block' }} />,
             contactSupport: (
-              <Hyperlink
-                destination={CONTACT_SUPPORT_URL}
-                target="_blank"
-                rel="noopener noreferrer"
+              <ExternalLink
+                href={CONTACT_SUPPORT_URL}
                 onClick={() => sendEnterpriseCheckoutTrackingEvent({
                   checkoutIntentId: checkoutIntent?.id ?? null,
                   checkoutIntentUuid: checkoutIntent?.uuid ?? null,
                   eventName: EVENT_NAMES.SUBSCRIPTION_CHECKOUT.CONTACT_SUPPORT_LINK_CLICKED,
                 })}
-                showLaunchIcon={false}
               >
                 <FormattedMessage
                   id="checkout.orderDetails.contactSupport"
                   defaultMessage="contact support"
                   description="Link text for contacting support"
                 />
-              </Hyperlink>
+              </ExternalLink>
             ),
           }}
         />

--- a/src/components/billing-details-pages/ContactSupport/ContactSupport.tsx
+++ b/src/components/billing-details-pages/ContactSupport/ContactSupport.tsx
@@ -17,7 +17,7 @@ const ContactSupport = () => {
           defaultMessage="For questions about your subscription or our{lineBreak}cancellation procedures, please {contactSupport}"
           description="Help text with link to contact support"
           values={{
-            lineBreak: <span style={{ display: 'block' }} />,
+            lineBreak: <br />,
             contactSupport: (
               <ExternalLink
                 href={CONTACT_SUPPORT_URL}


### PR DESCRIPTION
[https://2u-internal.atlassian.net/browse/ENT-12145](https://2u-internal.atlassian.net/browse/ENT-12145)

Add launch icon to Contact Support link

Replaces the raw Paragon Hyperlink in ContactSupport with the shared ExternalLink component so the "contact support" link displays the external-link (launch) icon, matching other outbound links in the app. Also adjusts the layout so the help text wraps correctly.